### PR TITLE
Ensure $dhcp_dir exists

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,12 @@ class dhcp (
       }
   }
 
+  file {
+      $dhcp_dir:
+          mode    => '0755',
+          require => Package[$packagename],
+  }
+
   # Only debian and ubuntu have this style of defaults for startup.
   case $::operatingsystem {
     'debian','ubuntu': {


### PR DESCRIPTION
This also ensures the correct permissions which are 750 by default on RH. This in turn means foreman-proxy can't read the DHCP file.
