### PR TITLE
Remove ntpservers call from dhcp code

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Define the server and the zones it will be responsible for.
         '1.0.10.in-addr.arpa',
         ],
       nameservers  => ['10.0.1.20'],
-      ntpservers   => ['us.pool.ntp.org'],
       interfaces   => ['eth0'],
       dnsupdatekey => "/etc/bind/keys.d/$ddnskeyname",
       require      => Bind::Key[ $ddnskeyname ],

--- a/manifests/disable.pp
+++ b/manifests/disable.pp
@@ -4,7 +4,6 @@ class dhcp::disable {
   $dhcp_dir    = $dhcp::params::dhcp_dir
   $dnsdomain   = $dhcp::params::dnsdomain
   $nameservers = $dhcp::params::nameservers
-  $ntpserver   = $dhcp::params::ntpserver
   $pxeserver   = $dhcp::params::pxeserver
   $filename    = $dhcp::params::filename
   $logfacility = $dhcp::params::logfacility

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,6 @@
 class dhcp (
     $dnsdomain,
     $nameservers,
-    $ntpservers,
     $interfaces   = undef,
     $interface    = 'NOTSET',
     $dnsupdatekey = undef,

--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -24,7 +24,6 @@ ddns-update-style none;
 
 option domain-name "<%= dnsdomain.first %>";
 option domain-name-servers <%= nameservers.join( ', ') %>;
-option ntp-servers <%= ntpservers.join( ', ') %>;
 
 allow booting;
 allow bootp;

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -6,7 +6,6 @@ class { 'dhcp':
     '1.1.10.in-addr.arpa',
     ],
   nameservers  => ['10.1.1.10'],
-  ntpservers   => ['us.pool.ntp.org'],
   interfaces   => ['eth0'],
   dnsupdatekey => "/etc/bind/keys.d/$::ddnskeyname",
   require      => Bind::Key[$::ddnskeyname],


### PR DESCRIPTION
Removes ntp from this modules, requires same branch name from foreman_proxy
