### PR TITLE
#1956 fix_dhcp_module-static_leases

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -9,7 +9,7 @@ define dhcp::host (
 
   $dhcp_dir = $dhcp::params::dhcp_dir
 
-  concat::fragment { "dhcp.hosts+10_${name}.hosts":
+  concat_fragment { "dhcp.hosts+10_${name}.hosts":
     content => template('dhcp/dhcpd.host.erb'),
   }
 


### PR DESCRIPTION
Current code fails to setup static DHCP leases when using 'dhcp::host'
