### PR TITLE
remove domain-name option

### DIFF
--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -22,7 +22,6 @@ zone <%= dom %>. {
 ddns-update-style none;
 <% end -%>
 
-option domain-name "<%= @dnsdomain.first %>";
 option domain-name-servers <%= @nameservers.join( ', ') %>;
 
 allow booting;


### PR DESCRIPTION
When the domain-name option is present all hosts will get the same domain via DHCP even if host is provisioned with a different domain in Foreman.  This causes last step in preseed to fail because request comes from a different FQDN to what was provisioned, results in a new FQDN being registered in Foreman, etc. Removing the domain-name option fixes this.
