### PR TITLE
Replace package name for Debian / Ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class dhcp::params {
 
   $packagename = $::operatingsystem ? {
     /(redhat|centos|fedora|Scientific)/ => 'dhcp',
-    /(Ubuntu|Debian)/                   => 'dhcp3-server',
+    /(Ubuntu|Debian)/                   => 'isc-dhcp-server',
     darwin                              => 'dhcp',
     default                             => 'dhcp',
   }


### PR DESCRIPTION
On Debian, installing the virtual packages dhcp3-server causes puppet to do:

```
Notice: /Stage[main]/Dhcp/Package[dhcp3-server]/ensure: ensure changed 'purged' to 'present'
```

on every run.
