### PR TITLE
Add support for configuring omapi

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,14 +1,17 @@
 class dhcp (
     $dnsdomain,
     $nameservers,
-    $interfaces   = undef,
-    $interface    = 'NOTSET',
-    $dnskeyname   = 'rndc-key',
-    $dnsupdatekey = undef,
-    $pxeserver    = undef,
-    $pxefilename  = undef,
-    $logfacility  = 'local7',
-    $dhcp_monitor = true
+    $interfaces     = undef,
+    $interface      = 'NOTSET',
+    $dnskeyname     = 'rndc-key',
+    $dnsupdatekey   = undef,
+    $pxeserver      = undef,
+    $pxefilename    = undef,
+    $logfacility    = 'local7',
+    $dhcp_monitor   = true,
+    $omapiport      = undef,
+    $omapialgorithm = undef,
+    $omapisecret    = undef
 ) {
 
   include dhcp::params

--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -40,4 +40,12 @@ filename "<%= @pxefilename %>";
 
 log-facility <%= @logfacility %>;
 
+<% if has_variable?( 'omapiport' ) and has_variable?( 'omapisecret' ) and has_variable?( 'omapialgorithm' ) then -%>
+omapi-port <%= @omapiport %>;
+key omapi_key {
+  algorithm <%= @omapialgorithm %>;
+  secret "<%= @omapisecret %>";
+}
+<% end -%>
+
 include "<%= @dhcp_dir %>/dhcpd.hosts";


### PR DESCRIPTION
I enhanced your puppet-module with a set of keys to be able to secure the isc-dhcp with omapi as you suggest in http://projects.theforeman.org/projects/smart-proxy/wiki/ISC_DHCP