### PR TITLE
domain-name per pool

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,9 +9,9 @@ class dhcp (
   $pxefilename  = undef,
   $logfacility  = 'local7',
   $dhcp_monitor = true,
-  $dhcp_dir    = $dhcp::params::dhcp_dir,
-  $packagename = $dhcp::params::packagename,
-  $servicename = $dhcp::params::servicename,
+  $dhcp_dir     = $dhcp::params::dhcp_dir,
+  $packagename  = $dhcp::params::packagename,
+  $servicename  = $dhcp::params::servicename,
 ) inherits dhcp::params {
 
   # Incase people set interface instead of interfaces work around

--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -1,9 +1,10 @@
 define dhcp::pool (
     $network,
     $mask,
-    $range = false,
-    $gateway = false,
-    $pxeserver = undef,
+    $range       = false,
+    $gateway     = false,
+    $pxeserver   = undef,
+    $domain_name = undef,
   ) {
 
     include dhcp::params

--- a/spec/defines/pool_spec.rb
+++ b/spec/defines/pool_spec.rb
@@ -16,9 +16,9 @@ describe 'dhcp::pool' do
     it {
         content = subject.resource('concat_fragment', 'dhcp.conf+70_mypool.dhcp').send(:parameters)[:content]
         content.split("\n").reject { |c| c =~ /(^\s*#|^$)/ }.should == [
-          "subnet 10.0.0.0 netmask 255.255.255.0 {",
-          "  option subnet-mask 255.255.255.0;",
-          "}",
+          'subnet 10.0.0.0 netmask 255.255.255.0 {',
+          '  option subnet-mask 255.255.255.0;',
+          '}',
         ]
     }
   end
@@ -36,16 +36,16 @@ describe 'dhcp::pool' do
     it {
         content = subject.resource('concat_fragment', 'dhcp.conf+70_mypool.dhcp').send(:parameters)[:content]
         content.split("\n").reject { |c| c =~ /(^\s*#|^$)/ }.should == [
-          "subnet 10.0.0.0 netmask 255.255.255.0 {",
-          "  pool",
-          "  {",
-          "    range 10.0.0.10 - 10.0.0.50;",
-          "  }",
-          '  option domain-name 'example.com';',
-          "  option subnet-mask 255.255.255.0;",
-          "  option routers 10.0.0.1;",
-          "  next-server 10.0.0.2;",
-          "}",
+          'subnet 10.0.0.0 netmask 255.255.255.0 {',
+          '  pool',
+          '  {',
+          '    range 10.0.0.10 - 10.0.0.50;',
+          '  }',
+          '  option domain-name "example.com";',
+          '  option subnet-mask 255.255.255.0;',
+          '  option routers 10.0.0.1;',
+          '  next-server 10.0.0.2;',
+          '}',
         ]
     }
   end

--- a/spec/defines/pool_spec.rb
+++ b/spec/defines/pool_spec.rb
@@ -25,11 +25,12 @@ describe 'dhcp::pool' do
 
   describe 'full parameters' do
     let :params do {
-      :network   => '10.0.0.0',
-      :mask      => '255.255.255.0',
-      :range     => '10.0.0.10 - 10.0.0.50',
-      :gateway   => '10.0.0.1',
-      :pxeserver => '10.0.0.2',
+      :network     => '10.0.0.0',
+      :mask        => '255.255.255.0',
+      :range       => '10.0.0.10 - 10.0.0.50',
+      :gateway     => '10.0.0.1',
+      :pxeserver   => '10.0.0.2',
+      :domain_name => 'example.com',
     } end
 
     it {
@@ -40,6 +41,7 @@ describe 'dhcp::pool' do
           "  {",
           "    range 10.0.0.10 - 10.0.0.50;",
           "  }",
+          '  option domain-name 'example.com';',
           "  option subnet-mask 255.255.255.0;",
           "  option routers 10.0.0.1;",
           "  next-server 10.0.0.2;",

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -9,6 +9,9 @@ subnet <%= @network %> netmask <%= @mask %> {
   }
 <% end -%>
 
+<% if @domain_name -%>
+  option domain-name "<%= @domain_name %>";
+<% end -%>
   option subnet-mask <%= @mask %>;
 <% if @gateway -%>
   option routers <%= @gateway %>;


### PR DESCRIPTION
This adds support for a `domain-name` option per address pool allowing the service of multiple domains from a single machine.  It allows a fix to an infinite build loop I discovers where the host receives conflicting domains from Foreman and DHCP and incorrectly reports its FQDN during the build process.  Also included are two style commits.