### PR TITLE
Allow empty range parameter

### DIFF
--- a/spec/defines/pool_spec.rb
+++ b/spec/defines/pool_spec.rb
@@ -23,6 +23,23 @@ describe 'dhcp::pool' do
     }
   end
 
+  describe 'with empty string range' do
+    let :params do {
+      :network => '10.0.0.0',
+      :mask    => '255.255.255.0',
+      :range   => '',
+    } end
+
+    it {
+        content = subject.resource('concat_fragment', 'dhcp.conf+70_mypool.dhcp').send(:parameters)[:content]
+        content.split("\n").reject { |c| c =~ /(^\s*#|^$)/ }.should == [
+          "subnet 10.0.0.0 netmask 255.255.255.0 {",
+          "  option subnet-mask 255.255.255.0;",
+          "}",
+        ]
+    }
+  end
+
   describe 'full parameters' do
     let :params do {
       :network     => '10.0.0.0',

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -2,7 +2,7 @@
 # <%= @name %>
 #################################
 subnet <%= @network %> netmask <%= @mask %> {
-<% if @range -%>
+<% if @range and !@range.empty? -%>
   pool
   {
     range <%= @range %>;


### PR DESCRIPTION
When a user would pass an empty range parameter, it would result into

```
pool
{
  range ;
}
```

dhcpd would fail to start after that. With this patch, the whole pool
block is omitted.

Closes GH-29