### PR TITLE
Remove unused code

### DIFF
--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -7,10 +7,6 @@ define dhcp::pool (
   $pxeserver = undef,
 ) {
 
-  include dhcp::params
-
-  $dhcp_dir = $dhcp::params::dhcp_dir
-
   concat_fragment { "dhcp.conf+70_${name}.dhcp":
     content => template('dhcp/dhcpd.pool.erb'),
   }


### PR DESCRIPTION
In 142c1fd3357e256b2437f6c6e60b8e2f55dca8a5 the use of the $dhcp_dir parameter was removed but not the code itself.