### PR TITLE
Clean up host

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -5,9 +5,6 @@ define dhcp::host (
 ) {
 
   $host = $name
-  include dhcp::params
-
-  $dhcp_dir = $dhcp::params::dhcp_dir
 
   concat_fragment { "dhcp.hosts+10_${name}.hosts":
     content => template('dhcp/dhcpd.host.erb'),


### PR DESCRIPTION
Since 142c1fd3357e256b2437f6c6e60b8e2f55dca8a5 the $dhcp_dir variable is unused.