### PR TITLE
Option Static routes support - RFC 3442

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,17 @@ Override global attributes with pool specific
       nameservers => ['10.0.1.2', '10.0.2.2'],
       pxeserver   => '10.0.1.2',
     }
+    
+For the support of static routes (RFC3442):
 
+    dhcp::pool{ 'ops.dc1.example.net':
+      network => '10.0.1.0',
+      mask    => '255.255.255.0',
+      range   => '10.0.1.100 10.0.1.200',
+      gateway => '10.0.1.1',
+      static_routes =>  [ { 'mask' => '32', 'network' => '169.254.169.254', 'gateway' => $ip } ],
+    }
+    
 ### dhcp::host
 Create host reservations.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@ class dhcp (
   $dhcp_dir           = $dhcp::params::dhcp_dir,
   $packagename        = $dhcp::params::packagename,
   $servicename        = $dhcp::params::servicename,
+  $option_static_route = undef,
 ) inherits dhcp::params {
 
   # Incase people set interface instead of interfaces work around

--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -8,6 +8,7 @@ define dhcp::pool (
   $nameservers = undef,
   $pxeserver   = undef,
   $domain_name = undef,
+  $static_routes = undef,
 ) {
 
   concat_fragment { "dhcp.conf+70_${name}.dhcp":

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -41,6 +41,7 @@ describe 'dhcp' do
           :dnsupdatekey => 'mydnsupdatekey',
           :pxeserver    => '10.0.0.5',
           :pxefilename  => 'mypxefilename',
+          :option_static_route => true,
         } end
 
         let(:facts) do {
@@ -72,6 +73,8 @@ describe 'dhcp' do
             'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
             'option fqdn.rcode2            255;',
             'option pxegrub code 150 = text ;',
+            'option rfc3442-classless-static-routes code 121 = array of integer 8;',
+            'option ms-classless-static-routes code 249 = array of integer 8;',
             'next-server 10.0.0.5;',
             'filename "mypxefilename";',
             'log-facility local7;',

--- a/spec/defines/pool_spec.rb
+++ b/spec/defines/pool_spec.rb
@@ -51,6 +51,7 @@ describe 'dhcp::pool' do
       :nameservers => ['10.0.0.2', '10.0.0.4'],
       :pxeserver   => '10.0.0.2',
       :domain_name => 'example.org',
+      :static_routes => [ { 'mask' => '24', 'network' => '10.0.1.0', 'gateway' => '10.0.0.2' } ],
     } end
 
     it {
@@ -61,9 +62,11 @@ describe 'dhcp::pool' do
           "  {",
           "    range 10.0.0.10 - 10.0.0.50;",
           "  }",
-          "  option domain-name example.org;",
+          "  option domain-name \"example.org\";",
           "  option subnet-mask 255.255.255.0;",
           "  option routers 10.0.0.1;",
+          "  option rfc3442-classless-static-routes 24, 10, 0, 1, 0, 10, 0, 0, 2;",
+          "  option ms-classless-static-routes  24, 10, 0, 1, 0, 10, 0, 0, 2;",
           "  option ntp-servers 10.0.0.2;",
           "  max-lease-time 300;",
           "  option domain-name-servers 10.0.0.2, 10.0.0.4;",

--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -34,6 +34,11 @@ option fqdn.no-client-update    on;  # set the "O" and "S" flag bits
 option fqdn.rcode2            255;
 option pxegrub code 150 = text ;
 
+<% if has_variable?( 'option_static_route' ) && @option_static_route -%>
+option rfc3442-classless-static-routes code 121 = array of integer 8;
+option ms-classless-static-routes code 249 = array of integer 8;
+<% end -%>
+
 <% if has_variable?( 'pxeserver' ) &&
   has_variable?( 'pxefilename' ) &&
   @pxeserver &&

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -10,11 +10,17 @@ subnet <%= @network %> netmask <%= @mask %> {
 <% end -%>
 
 <% if @domain_name && !@domain_name.strip.empty? -%>
-  option domain-name <%= @domain_name %>;
+  option domain-name "<%= @domain_name %>";
 <% end -%>
   option subnet-mask <%= @mask %>;
 <% if @gateway && !@gateway.strip.empty? -%>
   option routers <%= @gateway %>;
+<% end -%>
+<% if @static_routes
+  @static_routes.each do |static_route| -%>
+  option rfc3442-classless-static-routes <%= static_route['mask'] %>, <%= static_route['network'].split('.').join(', ') %>, <%= static_route['gateway'].split('.').join(', ') %>;
+  option ms-classless-static-routes  <%= static_route['mask'] %>, <%= static_route['network'].split('.').join(', ') %>, <%= static_route['gateway'].split('.').join(', ') %>;
+<%   end -%>
 <% end -%>
 <% if @options.is_a? Array -%>
 <%   @options.each do |opt| -%>


### PR DESCRIPTION
This PR add an option to add static routes with DHCP.
See:
 * https://tools.ietf.org/html/rfc3442
 * https://ercpe.de/blog/pushing-static-routes-with-isc-dhcp-server