### PR TITLE
Added quotes to domain name

### DIFF
--- a/spec/defines/pool_spec.rb
+++ b/spec/defines/pool_spec.rb
@@ -61,7 +61,7 @@ describe 'dhcp::pool' do
           "  {",
           "    range 10.0.0.10 - 10.0.0.50;",
           "  }",
-          "  option domain-name example.org;",
+          "  option domain-name \"example.org\";",
           "  option subnet-mask 255.255.255.0;",
           "  option routers 10.0.0.1;",
           "  option ntp-servers 10.0.0.2;",

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -10,7 +10,7 @@ subnet <%= @network %> netmask <%= @mask %> {
 <% end -%>
 
 <% if @domain_name && !@domain_name.strip.empty? -%>
-  option domain-name <%= @domain_name %>;
+  option domain-name "<%= @domain_name %>";
 <% end -%>
   option subnet-mask <%= @mask %>;
 <% if @gateway && !@gateway.strip.empty? -%>


### PR DESCRIPTION
Domain names were missing quotes, effectively failing dhcp to start with error on parsing config file. This is a fix.