### PR TITLE
Feature/dhcpclass

### DIFF
--- a/manifests/dhcp_class.pp
+++ b/manifests/dhcp_class.pp
@@ -1,9 +1,10 @@
 define dhcp::dhcp_class (
   $parameters
 ) {
-    concat::fragment { "dhcp.conf+50_${name}.dhcp":
+  concat::fragment { "dhcp.conf+50_${name}.dhcp":
     target  => "${::dhcp::dhcp_dir}/dhcpd.conf",
     content => template('dhcp/dhcpd.class.erb'),
     order   => "50-${name}",
   }
 }
+

--- a/manifests/dhcp_class.pp
+++ b/manifests/dhcp_class.pp
@@ -1,0 +1,9 @@
+define dhcp::dhcp_class (
+  $parameters
+) {
+    concat::fragment { "dhcp.conf+50_${name}.dhcp":
+    target  => "${::dhcp::dhcp_dir}/dhcpd.conf",
+    content => template('dhcp/dhcpd.class.erb'),
+    order   => "50-${name}",
+  }
+}

--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -1,14 +1,15 @@
 define dhcp::pool (
   $network,
   $mask,
-  $gateway     = undef,
-  $range       = undef,
-  $options     = undef,
-  $parameters  = undef,
-  $nameservers = undef,
-  $pxeserver   = undef,
-  $domain_name = undef,
-  $static_routes = undef,
+  $gateway         = undef,
+  $pool_parameters = undef,
+  $range           = undef,
+  $options         = undef,
+  $parameters      = undef,
+  $nameservers     = undef,
+  $pxeserver       = undef,
+  $domain_name     = undef,
+  $static_routes   = undef,
 ) {
 
   concat::fragment { "dhcp.conf+70_${name}.dhcp":

--- a/spec/defines/pool_spec.rb
+++ b/spec/defines/pool_spec.rb
@@ -41,16 +41,17 @@ describe 'dhcp::pool' do
 
   describe 'full parameters' do
     let :params do {
-      :network     => '10.0.0.0',
-      :mask        => '255.255.255.0',
-      :range       => '10.0.0.10 - 10.0.0.50',
-      :gateway     => '10.0.0.1',
-      :options     => 'ntp-servers 10.0.0.2',
-      :parameters  => 'max-lease-time 300',
-      :nameservers => ['10.0.0.2', '10.0.0.4'],
-      :pxeserver   => '10.0.0.2',
-      :domain_name => 'example.org',
-      :static_routes => [ { 'mask' => '24', 'network' => '10.0.1.0', 'gateway' => '10.0.0.2' } ],
+      :network          => '10.0.0.0',
+      :mask             => '255.255.255.0',
+      :pool_parameters  => 'allow members of "some-class"',
+      :range            => '10.0.0.10 - 10.0.0.50',
+      :gateway          => '10.0.0.1',
+      :options          => 'ntp-servers 10.0.0.2',
+      :parameters       => 'max-lease-time 300',
+      :nameservers      => ['10.0.0.2', '10.0.0.4'],
+      :pxeserver        => '10.0.0.2',
+      :domain_name      => 'example.org',
+      :static_routes    => [ { 'mask' => '24', 'network' => '10.0.1.0', 'gateway' => '10.0.0.2' } ],
     } end
 
     it {
@@ -58,6 +59,7 @@ describe 'dhcp::pool' do
         "subnet 10.0.0.0 netmask 255.255.255.0 {",
         "  pool",
         "  {",
+        "    allow members of \"some-class\";",
         "    range 10.0.0.10 - 10.0.0.50;",
         "  }",
         "  option domain-name \"example.org\";",

--- a/templates/dhcpd.class.erb
+++ b/templates/dhcpd.class.erb
@@ -1,0 +1,13 @@
+#################################
+# class <%= @name %>
+#################################
+class "<%= @name %>" {
+<% if @parameters.is_a? Array -%>
+<%   @parameters.each do |param| -%>
+  <%= param %>;
+<% end -%>
+<% elsif @parameters && !@parameters.strip.empty? -%>
+  <%= @parameters %>;
+<% end -%>
+}
+

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -5,6 +5,13 @@ subnet <%= @network %> netmask <%= @mask %> {
 <% if @range && !@range.strip.empty? -%>
   pool
   {
+<% if @pool_parameters.is_a? Array -%>
+<%   @pool_parameters.each do |param| -%>
+    <%= param %>;
+<%   end -%>
+<% elsif @pool_parameters && !@pool_parameters.strip.empty? -%>
+    <%= @pool_parameters %>;
+<% end -%>
     range <%= @range %>;
   }
 <% end -%>


### PR DESCRIPTION
This will introduce support for dhcp class options such as
```
class "vendorXmachines" {
   match pick-first-value (option dhcp-client-identifier, hardware);
}
```

Also this extends the existing pool fragment to allow for options (such as 'allow members of') inside a specific pool (for using with classes e.g.)
```
subnet 10.2.0.0 netmask 255.255.255.0 {
  pool
  {
    allow members of "vendorXmachines";
    range 10.2.0.3 10.2.0.250;
  }
```
