### PR TITLE
Add arbitrary options via array to dhcpd.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class dhcp (
   $packagename        = $dhcp::params::packagename,
   $servicename        = $dhcp::params::servicename,
   $option_static_route = undef,
+  $options            = undef,
 ) inherits dhcp::params {
 
   # Incase people set interface instead of interfaces work around

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -42,6 +42,7 @@ describe 'dhcp' do
           :pxeserver    => '10.0.0.5',
           :pxefilename  => 'mypxefilename',
           :option_static_route => true,
+          :options      => ['provision-url code 224 = text', 'provision-type code 225 = text'],
         } end
 
         let(:facts) do {
@@ -75,6 +76,8 @@ describe 'dhcp' do
             'option pxegrub code 150 = text ;',
             'option rfc3442-classless-static-routes code 121 = array of integer 8;',
             'option ms-classless-static-routes code 249 = array of integer 8;',
+            'option provision-url code 224 = text;',
+            'option provision-type code 225 = text;',
             'next-server 10.0.0.5;',
             'filename "mypxefilename";',
             'log-facility local7;',

--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -39,6 +39,14 @@ option rfc3442-classless-static-routes code 121 = array of integer 8;
 option ms-classless-static-routes code 249 = array of integer 8;
 <% end -%>
 
+<% if @options.is_a? Array -%>
+<%   @options.each do |option| -%>
+option <%= option %>;
+<%   end -%>
+<% elsif @options && !@options.strip.empty? -%>
+  option <%= @options %>;
+<% end -%>
+
 <% if has_variable?( 'pxeserver' ) &&
   has_variable?( 'pxefilename' ) &&
   @pxeserver &&


### PR DESCRIPTION
It makes more sense to add custom options via an array, then to specify an entry for all 255 possibile dhcp options as detailed in several RFCs.