### PR TITLE
add support to set search domains in the generated dhcpd configuration file

### DIFF
--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -10,6 +10,7 @@ define dhcp::pool (
   $pxeserver       = undef,
   $domain_name     = undef,
   $static_routes   = undef,
+  $search_domains  = undef,
 ) {
 
   concat::fragment { "dhcp.conf+70_${name}.dhcp":

--- a/spec/defines/pool_spec.rb
+++ b/spec/defines/pool_spec.rb
@@ -52,6 +52,7 @@ describe 'dhcp::pool' do
       :pxeserver        => '10.0.0.2',
       :domain_name      => 'example.org',
       :static_routes    => [ { 'mask' => '24', 'network' => '10.0.1.0', 'gateway' => '10.0.0.2' } ],
+      :search_domains   => ['example.org', 'other.example.org'],
     } end
 
     it {
@@ -70,6 +71,7 @@ describe 'dhcp::pool' do
         "  option ntp-servers 10.0.0.2;",
         "  max-lease-time 300;",
         "  option domain-name-servers 10.0.0.2, 10.0.0.4;",
+        "  option domain-search \"example.org, other.example.org\";",
         "  next-server 10.0.0.2;",
         "}",
       ])

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -48,6 +48,11 @@ subnet <%= @network %> netmask <%= @mask %> {
 <% elsif @nameservers -%>
   option domain-name-servers <%= @nameservers %>;
 <% end -%>
+<% if @search_domains and @search_domains.is_a? Array -%>
+  option domain-search "<%= @search_domains.sort.join(', ') %>";
+<% elsif @search_domains -%>
+  option domain-search "<%= @search_domains %>";
+<% end -%>
 <% if @pxeserver -%>
   next-server <%= @pxeserver %>;
 <% end -%>


### PR DESCRIPTION
I added support to set the search domains to be added to the dhpcd.conf file since we need it in our foreman environment.