### PR TITLE
pin stdlib to <5.0.0 for Puppet 2.7 compatibility

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,9 @@
 fixtures:
   repositories:
-    concat:      'https://github.com/puppetlabs/puppetlabs-concat'
-    stdlib:      'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+    concat: 'https://github.com/puppetlabs/puppetlabs-concat'
+    stdlib:
+      repo: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+      branch: '4.7.x'
 
   symlinks:
     dhcp: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -18,6 +18,10 @@
     {
       "name": "puppetlabs/concat",
       "version_requirement": ">= 1.0.0 < 3.0.0"
+    },
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": "< 5.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
While -dhcp does not require stdlib itself, concat does.