### PR TITLE
Add support for setting up OMAPI key

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,8 @@ class dhcp (
   $max_lease_time     = 86400,
   $dnskeyname         = 'rndc-key',
   $dnsupdatekey       = undef,
+  $omapi_name         = undef,
+  $omapi_key          = undef,
   $pxeserver          = undef,
   $pxefilename        = undef,
   $logfacility        = 'local7',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -40,6 +40,8 @@ describe 'dhcp' do
         let(:params) do {
           :interfaces   => ['eth0'],
           :dnsupdatekey => 'mydnsupdatekey',
+          :omapi_name	=> 'mykeyname',
+          :omapi_key	=> 'myomapikey',
           :pxeserver    => '10.0.0.5',
           :pxefilename  => 'mypxefilename',
           :option_static_route => true,
@@ -58,6 +60,11 @@ describe 'dhcp' do
         it {
           verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
             'omapi-port 7911;',
+            'key mykeyname {',
+            '  algorithm HMAC-MD5;',
+            '  secret "myomapikey";',
+            '}',
+            'omapi-key mykeyname;',
             'default-lease-time 43200;',
             'max-lease-time 86400;',
             'authoritative;',

--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -1,5 +1,12 @@
 # dhcpd.conf
 omapi-port 7911;
+<% if @omapi_name && @omapi_key -%>
+key <%= @omapi_name %> {
+  algorithm HMAC-MD5;
+  secret "<%= @omapi_key %>";
+}
+omapi-key <%= @omapi_name %>;
+<% end -%>
 
 default-lease-time <%= @default_lease_time %>;
 max-lease-time <%= @max_lease_time %>;


### PR DESCRIPTION
This is needed so that the puppet-foreman_proxy module will be able to set up OMAPI in the dhcp server when the foreman-installer is called with the dhcp-key-name and dhcp-key-secret options.