### PR TITLE
Add ddns-domainname and ddns-rev-domainname option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,8 @@ class dhcp (
   $options            = undef,
   $authoritative      = false,
   $dhcp_root_group    = $dhcp::params::root_group,
+  $ddns_domainname    = undef,
+  $ddns_rev_domainname= undef,
   $pools              = {},
   $hosts              = {},
 ) inherits dhcp::params {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -47,6 +47,8 @@ describe 'dhcp' do
           :option_static_route => true,
           :options      => ['provision-url code 224 = text', 'provision-type code 225 = text'],
           :authoritative => true,
+          :ddns_domainname => 'example.org',
+          :ddns_rev_domainname => 'in-addr.arpa',
         } end
 
         let(:facts) do {
@@ -72,6 +74,8 @@ describe 'dhcp' do
             'ddns-update-style interim;',
             'update-static-leases on;',
             'use-host-decl-names on;',
+	    'ddns-domainname "example.org";',
+	    'ddns-rev-domainname "in-addr.arpa";',
             'include "mydnsupdatekey";',
             'zone example.org. {',
             '  primary 8.8.8.8;',

--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -23,6 +23,13 @@ ddns-update-style interim;
 update-static-leases on;
 use-host-decl-names on;
 
+<% if @ddns_domainname and !@ddns_domainname.empty? -%>
+ddns-domainname "<%= @ddns_domainname %>";
+<% end -%>
+<% if @ddns_rev_domainname and !@ddns_rev_domainname.empty? -%>
+ddns-rev-domainname "<%= @ddns_rev_domainname %>";
+<% end -%>
+
 # Key from bind
 include "<%= @dnsupdatekey %>";
 <% @dnsdomain.each do |dom| -%>


### PR DESCRIPTION
ddns-domainname is needed when multiple domains set for a zone
ddns-rev-domainname is needed to support reverse lookup update