### PR TITLE
Add support for the range param being an array

### DIFF
--- a/spec/defines/pool_spec.rb
+++ b/spec/defines/pool_spec.rb
@@ -39,6 +39,27 @@ describe 'dhcp::pool' do
     }
   end
 
+  describe 'with range array' do
+    let :params do {
+      :network => '10.0.0.0',
+      :mask    => '255.255.255.0',
+      :range   => ['10.0.0.10 - 10.0.0.50','10.0.0.100 - 10.0.0.150'],
+    } end
+
+    it {
+      verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+70_mypool.dhcp', [
+        'subnet 10.0.0.0 netmask 255.255.255.0 {',
+        '  pool',
+        '  {',
+        '    range 10.0.0.10 - 10.0.0.50;',
+        '    range 10.0.0.100 - 10.0.0.150;',
+        '  }',
+        '  option subnet-mask 255.255.255.0;',
+        '}',
+      ])
+    }
+  end
+
   describe 'full parameters' do
     let :params do {
       :network          => '10.0.0.0',

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -2,7 +2,7 @@
 # <%= @name %>
 #################################
 subnet <%= @network %> netmask <%= @mask %> {
-<% if @range && !@range.strip.empty? -%>
+<% if (@range && @range.is_a?(String) && !@range.strip.empty?) || (@range && @range.is_a?(Array)) -%>
   pool
   {
 <% if @pool_parameters.is_a? Array -%>
@@ -12,7 +12,13 @@ subnet <%= @network %> netmask <%= @mask %> {
 <% elsif @pool_parameters && !@pool_parameters.strip.empty? -%>
     <%= @pool_parameters %>;
 <% end -%>
+<% if @range and @range.is_a? Array -%>
+<% @range.each do |rng| -%>
+    range <%= rng %>;
+<% end -%>
+<% elsif @range && !@range.strip.empty? -%>
     range <%= @range %>;
+<% end -%>
   }
 <% end -%>
 


### PR DESCRIPTION
This allows the range param to be passed either as a string or an array. Having multiple range definitions in a pool is supported by dhcpd. This has the added benefit of being API compatible with puppetlabs-dhcp for the range param.