### PR TITLE
FreeBSD uses ISC DHCP 4.3 now

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class dhcp::params {
 
     /^(FreeBSD|DragonFly)$/: {
       $dhcp_dir    = '/usr/local/etc'
-      $packagename = 'isc-dhcp42-server'
+      $packagename = 'isc-dhcp43-server'
       $servicename = 'isc-dhcpd'
       $root_group  = 'wheel'
     }


### PR DESCRIPTION
4.2 was deleted in freebsd/freebsd-ports@359dff8, the paths to the files are still the same.
@fraenki, could you have a look?