### PR TITLE
Feature/ddns no key

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,3 +25,9 @@ PuppetLintParamDocs.define_selective do |config|
 end
 
 task :default => [:validate, :lint, :spec]
+task :test => [
+  :metadata_lint,
+  :syntax,
+  :lint,
+  :spec,
+]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@ class dhcp (
   $options            = undef,
   $authoritative      = false,
   $dhcp_root_group    = $dhcp::params::root_group,
+  $ddns_updates       = undef,
   $ddns_domainname    = undef,
   $ddns_rev_domainname= undef,
   $pools              = {},

--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -17,7 +17,7 @@ max-lease-time <%= @max_lease_time %>;
 authoritative;
 <% end -%>
 
-<% if has_variable?( 'dnsupdatekey' ) and @dnsupdatekey -%>
+<% if (has_variable?( 'dnsupdatekey' ) && @dnsupdatekey) || (has_variable?( 'ddns_updates' ) && @ddns_updates) -%>
 ddns-updates on;
 ddns-update-style interim;
 update-static-leases on;
@@ -31,11 +31,15 @@ ddns-rev-domainname "<%= @ddns_rev_domainname %>";
 <% end -%>
 
 # Key from bind
+<% if @dnsupdatekey and !@dnsupdatekey.empty? -%>
 include "<%= @dnsupdatekey %>";
+<% end -%>
 <% @dnsdomain.each do |dom| -%>
 zone <%= dom %>. {
   primary <%= @nameservers.first %>;
+<% if @dnsupdatekey and !@dnsupdatekey.empty? -%>
   key <%= @dnskeyname%>;
+<% end -%>
 }
 <% end -%>
 <% else %>


### PR DESCRIPTION
In its current state the module only allows for turning on ddns updates if a key is provided. There are cases where insecure updates may be desired. For example when running isn-dhcp-server along with Microsoft DNS servers. This pull request creates 1 new variable, ddns_updates. If this variable is set then the template will add the ddns configs without the key.
