### PR TITLE
Remove unnecessary hash-signes from pool config

### DIFF
--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -1,6 +1,4 @@
-#################################
 # <%= @name %>
-#################################
 subnet <%= @network %> netmask <%= @mask %> {
 <% if (@range && @range.is_a?(String) && !@range.strip.empty?) || (@range && @range.is_a?(Array)) -%>
   pool


### PR DESCRIPTION
This fixes #74 to allow proper naming within tools like webmin to display the pool name instead of `#################################`

