### PR TITLE
Add Archlinux support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,14 @@ class dhcp::params {
       $bootfiles   = {}
     }
 
+    'Archlinux': {
+      $dhcp_dir    = '/etc'
+      $packagename = 'dhcp'
+      $servicename = 'dhcpd4'
+      $root_group  = 'root'
+      $bootfiles   = {}
+    }
+
     'RedHat': {
       $dhcp_dir    = '/etc/dhcp'
       $packagename = 'dhcp'

--- a/metadata.json
+++ b/metadata.json
@@ -70,6 +70,9 @@
       ]
     },
     {
+      "operatingsystem": "Archlinux"
+    },
+    {
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
         "9",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -3,7 +3,14 @@ require 'spec_helper'
 describe 'dhcp' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
-      conf_path = (os =~ /^FreeBSD/i) ? '/usr/local/etc' : '/etc/dhcp'
+      conf_path = case os
+                  when /^FreeBSD/i
+                    '/usr/local/etc'
+                  when /^Archlinux/i
+                    '/etc'
+                  else
+                    '/etc/dhcp'
+                  end
       describe "dhcp class without any parameters on #{os}" do
         let(:params) do {
           :interfaces => ['eth0'],


### PR DESCRIPTION
Tested on my DHCP proxy, seems to work.

One caveat is that you can't set the listen interfaces on Arch. There's no config file to alter, you're expected to set ranges or write a different systemd unit - https://wiki.archlinux.org/index.php/Dhcpd#Listening_on_only_one_interface has the details.

This doesn't cause me any issues, and users can always write a systemd unit elsewhere in their catalog and then override the value of `servicename` - so maybe it just needs documenting somewhere?
