### PR TITLE
Fix classless static routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ For the support of static routes (RFC3442):
       network => '10.0.1.0',
       mask    => '255.255.255.0',
       range   => '10.0.1.100 10.0.1.200',
-      gateway => '10.0.1.1',
-      static_routes =>  [ { 'mask' => '32', 'network' => '169.254.169.254', 'gateway' => $ip } ],
+      gateway => $gw,
+      static_routes =>  [ { 'mask' => '32', 'network' => '169.254.169.254', 'gateway' => $ip },
+                          { 'mask' => '0',                                  'gateway' => $gw } ],
     }
 
 ### dhcp::host

--- a/spec/defines/pool_spec.rb
+++ b/spec/defines/pool_spec.rb
@@ -120,7 +120,8 @@ describe 'dhcp::pool' do
             :pxeserver        => '10.0.0.2',
             :mtu              => 9000,
             :domain_name      => 'example.org',
-            :static_routes    => [ { 'mask' => '24', 'network' => '10.0.1.0', 'gateway' => '10.0.0.2' } ],
+            :static_routes    => [ { 'mask' => '24', 'network' => '10.0.1.0', 'gateway' => '10.0.0.2' },
+                                   { 'mask' => '0',                           'gateway' => '10.0.0.1' } ],
             :search_domains   => ['example.org', 'other.example.org'],
           } end
 
@@ -135,8 +136,8 @@ describe 'dhcp::pool' do
               "  option domain-name \"example.org\";",
               "  option subnet-mask 255.255.255.0;",
               "  option routers 10.0.0.1;",
-              "  option rfc3442-classless-static-routes 24, 10, 0, 1, 0, 10, 0, 0, 2;",
-              "  option ms-classless-static-routes  24, 10, 0, 1, 0, 10, 0, 0, 2;",
+              "  option rfc3442-classless-static-routes 24, 10, 0, 1, 0, 10, 0, 0, 2, 0, 10, 0, 0, 1;",
+              "  option ms-classless-static-routes 24, 10, 0, 1, 0, 10, 0, 0, 2, 0, 10, 0, 0, 1;",
               "  option ntp-servers 10.0.0.2;",
               "  max-lease-time 300;",
               "  option domain-name-servers 10.0.0.2, 10.0.0.4;",

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -31,9 +31,18 @@ subnet <%= @network %> netmask <%= @mask %> {
   option routers <%= @gateway %>;
 <% end -%>
 <% if @static_routes
-  @static_routes.each do |static_route| -%>
-  option rfc3442-classless-static-routes <%= static_route['mask'] %>, <%= static_route['network'].split('.').join(', ') %>, <%= static_route['gateway'].split('.').join(', ') %>;
-  option ms-classless-static-routes  <%= static_route['mask'] %>, <%= static_route['network'].split('.').join(', ') %>, <%= static_route['gateway'].split('.').join(', ') %>;
+     ['rfc3442', 'ms'].each do |static_route_prefix| -%>
+  option <%= static_route_prefix %>-classless-static-routes <% -%>
+<%     @static_routes.each_with_index do |static_route, static_route_index| -%>
+<%=      static_route['mask'] %>, <% -%>
+<%       if static_route['network'] && !static_route['network'].split('.').empty? -%>
+<%=        static_route['network'].split('.').join(', ')%>, <% -%>
+<%       end -%>
+<%=      static_route['gateway'].split('.').join(', ') -%>
+<%       if static_route_index + 1 < @static_routes.length %>, <% -%>
+<%       else %>;<% -%>
+<%       end -%>
+<%     end %>
 <%   end -%>
 <% end -%>
 <% if @options.is_a? Array -%>


### PR DESCRIPTION
## Classless static routes are broken.
### Why?:
* Subsequent definitions of of `{rfc3442,ms}-classless-static-routes` override their predecessors.  Perhaps this was not true in older versions of `dhcpd`, although I doubt it.
* There is no ability to define a `/0` masked static route.  With `dhcpcd` and perhaps other DHCP clients, option 3 (router) is ignored when `rfc3442-classless-static-routes` is specified, meaning there is no non-hackish way to specify a default route.
### Have I tested this?
Yes, but only with Puppet 4.x and Debian family systems.
### Styling:
I've chosen a styling that I think appropriately balances readability of the template with readability of the resulting config.  There may be a better way to do this, I'm not that familiar with Ruby.  I am happy to make changes to better balance the two as per your preferences.