### PR TITLE
Add support for pxefilename for pools.

### DIFF
--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -10,6 +10,7 @@ define dhcp::pool (
   $mtu             = undef,
   $nameservers     = undef,
   $pxeserver       = undef,
+  $pxefilename     = undef,
   $domain_name     = undef,
   $static_routes   = undef,
   $search_domains  = undef,

--- a/spec/defines/pool_spec.rb
+++ b/spec/defines/pool_spec.rb
@@ -118,6 +118,7 @@ describe 'dhcp::pool' do
             :parameters       => 'max-lease-time 300',
             :nameservers      => ['10.0.0.2', '10.0.0.4'],
             :pxeserver        => '10.0.0.2',
+            :pxefilename      => 'pxelinux.0',
             :mtu              => 9000,
             :domain_name      => 'example.org',
             :static_routes    => [ { 'mask' => '24', 'network' => '10.0.1.0', 'gateway' => '10.0.0.2' },
@@ -147,6 +148,7 @@ describe 'dhcp::pool' do
               "  option domain-search \"example.org\", \"other.example.org\";",
               "  option interface-mtu 9000;",
               "  next-server 10.0.0.2;",
+              "  filename \"pxelinux.0\";",
               "  example append;",
               "}",
             ])

--- a/templates/dhcpd.pool.erb
+++ b/templates/dhcpd.pool.erb
@@ -78,6 +78,9 @@ subnet <%= @network %> netmask <%= @mask %> {
 <% if @pxeserver -%>
   next-server <%= @pxeserver %>;
 <% end -%>
+<% if @pxefilename -%>
+  filename "<%= @pxefilename %>";
+<% end -%>
 <% if @raw_append %>
   <%= @raw_append %>
 <% end -%>


### PR DESCRIPTION
This adds the possibility to override the filename for pxe booting per pool.

The filename is not an option, so use of $options is not possible. While $raw_append could be used to achieve the same goal, it's nice to have a separate argument for it. This also mirrors the argument list for init.pp more closely.