### PR TITLE
Allow turning bootp off

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,7 @@
 class dhcp (
   $dnsdomain          = $dhcp::params::dnsdomain,
   $nameservers        = ['8.8.8.8', '8.8.4.4'],
+  $bootp              = true,
   $ntpservers         = [],
   $interfaces         = undef,
   $interface          = 'NOTSET',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -205,6 +205,40 @@ describe 'dhcp' do
           ])
         }
       end
+
+      describe "without bootp" do
+        let(:params) do {
+          :interfaces => ['eth0'],
+          :bootp => false,
+        } end
+
+        let(:facts) do
+          facts.merge({
+            :concat_basedir => '/doesnotexist',
+            :domain         => 'example.org',
+          })
+        end
+
+        it { should compile.with_all_deps }
+
+        it {
+          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
+            'omapi-port 7911;',
+            'default-lease-time 43200;',
+            'max-lease-time 86400;',
+            'ddns-update-style none;',
+            'option domain-name "example.org";',
+            'option domain-name-servers 8.8.8.8, 8.8.4.4;',
+            "option ntp-servers none;",
+            'allow booting;',
+            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
+            'option fqdn.rcode2            255;',
+            'option pxegrub code 150 = text ;',
+            'log-facility local7;',
+            "include \"#{conf_path}/dhcpd.hosts\";",
+          ])
+        }
+      end
     end
   end
 end

--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -59,7 +59,9 @@ option ntp-servers none;
 <% end -%>
 
 allow booting;
+<% if @bootp -%>
 allow bootp;
+<% end -%>
 
 option fqdn.no-client-update    on;  # set the "O" and "S" flag bits
 option fqdn.rcode2            255;


### PR DESCRIPTION
Defaults to maintaining existing behaviour (bootp enabled). Also cleanly applies to the 3.2-stable branch as of the time of this PR.