### PR TITLE
Failover improvements

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,7 @@
 class dhcp (
   $dnsdomain          = $dhcp::params::dnsdomain,
   $nameservers        = ['8.8.8.8', '8.8.4.4'],
+  $bootp              = true,
   $ntpservers         = [],
   $interfaces         = undef,
   $interface          = 'NOTSET',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,8 @@
 class dhcp (
   $dnsdomain          = $dhcp::params::dnsdomain,
   $nameservers        = ['8.8.8.8', '8.8.4.4'],
-  $bootp              = true,
+  $failover           = false,
+  $bootp              = undef,
   $ntpservers         = [],
   $interfaces         = undef,
   $interface          = 'NOTSET',
@@ -47,6 +48,15 @@ class dhcp (
     fail ("You need to set \$interfaces in ${module_name}")
   } else {
     $dhcp_interfaces = $interfaces
+  }
+
+  # See https://tools.ietf.org/html/draft-ietf-dhc-failover-12 for why BOOTP is
+  # not supported in the failover protocol. Relay agents *can* be made to work
+  # so $bootp can be explicitly set to true to override this default.
+  if $bootp == undef {
+    $bootp_real = !$failover
+  } else {
+    $bootp_real = $bootp
   }
 
   package { $packagename:

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -205,6 +205,40 @@ describe 'dhcp' do
           ])
         }
       end
+
+      describe "without bootp" do
+        let(:params) do {
+          :interfaces => ['eth0'],
+          :bootp => false,
+        } end
+
+        let(:facts) do
+          facts.merge({
+            :concat_basedir => '/doesnotexist',
+            :domain         => 'example.org',
+          })
+        end
+
+        it { should compile.with_all_deps }
+
+        it {
+          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
+            'omapi-port 7911;',
+            'default-lease-time 43200;',
+            'max-lease-time 86400;',
+            'ddns-update-style none;',
+            'option domain-name "example.org";',
+            'option domain-name-servers 8.8.8.8, 8.8.4.4;',
+            "option ntp-servers none;",
+            'allow booting;',
+            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
+            'option fqdn.rcode2            255;',
+            'option pxegrub code 150 = text ;',
+            'log-facility local7;',
+            "include \"#{conf_path}/dhcpd.hosts\";",
+          ])
+        }
+      end
     end
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -239,6 +239,141 @@ describe 'dhcp' do
           ])
         }
       end
+      describe "without failover, bootp undef" do
+        let(:params) do {
+          :interfaces => ['eth0'],
+        } end
+
+        let(:facts) do
+          facts.merge({
+            :concat_basedir => '/doesnotexist',
+            :domain         => 'example.org',
+          })
+        end
+
+        it { should compile.with_all_deps }
+
+        it {
+          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
+            'omapi-port 7911;',
+            'default-lease-time 43200;',
+            'max-lease-time 86400;',
+            'ddns-update-style none;',
+            'option domain-name "example.org";',
+            'option domain-name-servers 8.8.8.8, 8.8.4.4;',
+            "option ntp-servers none;",
+            'allow booting;',
+            'allow bootp;',
+            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
+            'option fqdn.rcode2            255;',
+            'option pxegrub code 150 = text ;',
+            'log-facility local7;',
+            "include \"#{conf_path}/dhcpd.hosts\";",
+          ])
+        }
+      end
+      describe "with failover, bootp undef" do
+        let(:params) do {
+          :interfaces => ['eth0'],
+          :failover => true
+        } end
+
+        let(:facts) do
+          facts.merge({
+            :concat_basedir => '/doesnotexist',
+            :domain         => 'example.org',
+          })
+        end
+
+        it { should compile.with_all_deps }
+
+        it {
+          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
+            'omapi-port 7911;',
+            'default-lease-time 43200;',
+            'max-lease-time 86400;',
+            'ddns-update-style none;',
+            'option domain-name "example.org";',
+            'option domain-name-servers 8.8.8.8, 8.8.4.4;',
+            "option ntp-servers none;",
+            'allow booting;',
+            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
+            'option fqdn.rcode2            255;',
+            'option pxegrub code 150 = text ;',
+            'log-facility local7;',
+            "include \"#{conf_path}/dhcpd.hosts\";",
+          ])
+        }
+      end
+      describe "with failover, bootp true" do
+        let(:params) do {
+          :interfaces => ['eth0'],
+          :failover => true,
+          :bootp => true
+        } end
+
+        let(:facts) do
+          facts.merge({
+            :concat_basedir => '/doesnotexist',
+            :domain         => 'example.org',
+          })
+        end
+
+        it { should compile.with_all_deps }
+
+        it {
+          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
+            'omapi-port 7911;',
+            'default-lease-time 43200;',
+            'max-lease-time 86400;',
+            'ddns-update-style none;',
+            'option domain-name "example.org";',
+            'option domain-name-servers 8.8.8.8, 8.8.4.4;',
+            "option ntp-servers none;",
+            'allow booting;',
+            'allow bootp;',
+            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
+            'option fqdn.rcode2            255;',
+            'option pxegrub code 150 = text ;',
+            'log-facility local7;',
+            "include \"#{conf_path}/dhcpd.hosts\";",
+          ])
+        }
+      end
+      describe "with failover, bootp false" do
+        let(:params) do {
+          :interfaces => ['eth0'],
+          :failover => true,
+          :bootp => false
+        } end
+
+        let(:facts) do
+          facts.merge({
+            :concat_basedir => '/doesnotexist',
+            :domain         => 'example.org',
+          })
+        end
+
+        it { should compile.with_all_deps }
+
+        it {
+          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
+            'omapi-port 7911;',
+            'default-lease-time 43200;',
+            'max-lease-time 86400;',
+            'ddns-update-style none;',
+            'option domain-name "example.org";',
+            'option domain-name-servers 8.8.8.8, 8.8.4.4;',
+            "option ntp-servers none;",
+            'allow booting;',
+            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
+            'option fqdn.rcode2            255;',
+            'option pxegrub code 150 = text ;',
+            'log-facility local7;',
+            "include \"#{conf_path}/dhcpd.hosts\";",
+          ])
+        }
+      end
     end
   end
 end

--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -59,7 +59,7 @@ option ntp-servers none;
 <% end -%>
 
 allow booting;
-<% if @bootp -%>
+<% if @bootp_real -%>
 allow bootp;
 <% end -%>
 
@@ -113,10 +113,12 @@ log-facility <%= @logfacility %>;
 
 include "<%= @dhcp_dir %>/dhcpd.hosts";
 
+<% unless @failover -%>
 <% if @includes.is_a? Array -%>
 <% @includes.each do |include| -%>
 include "<%= include %>";
 <% end -%>
 <% elsif @includes && !@includes.strip.empty? -%>
 include "<%= @includes %>";
+<% end -%>
 <% end -%>

--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -59,7 +59,9 @@ option ntp-servers none;
 <% end -%>
 
 allow booting;
+<% if @bootp -%>
 allow bootp;
+<% end -%>
 
 option fqdn.no-client-update    on;  # set the "O" and "S" flag bits
 option fqdn.rcode2            255;

--- a/templates/dhcpd.conf.failover.erb
+++ b/templates/dhcpd.conf.failover.erb
@@ -13,3 +13,14 @@ failover peer "dhcp-failover" {
   split <%= @load_split %>;
 <% end -%>
 }
+
+<%# This just moves the includes from dhcp.conf.erb to here so that any
+includes that involve failover pools won't fail. -%>
+<% includes = scope.lookupvar('dhcp::includes') -%>
+<% if includes.is_a? Array -%>
+<% includes.each do |include| -%>
+include "<%= include %>";
+<% end -%>
+<% elsif includes && !includes.strip.empty? -%>
+include "<%= includes %>";
+<% end -%>


### PR DESCRIPTION
Moves dynamic includes *after* the failover configuration. BOOTP now defaults to off if failover is on and vice-versa. BOOTP can be explicitly set true or false regardless of failover, though. This enables safer default operation as defined in https://www.google.com/search?q=rfc+DHCP+Failover+Protocol.

This incorporates #97 as well.