### PR TITLE
Correct MAC address definition

### DIFF
--- a/types/macaddress.pp
+++ b/types/macaddress.pp
@@ -1,1 +1,1 @@
-type Dhcp::Macaddress = Pattern[/[0-9a-e]{1,2}(:[0-9a-e]{1,2}){5}/]
+type Dhcp::Macaddress = Pattern[/[0-9A-Fa-f]{1,2}(:[0-9A-Fa-f]{1,2}){5}/]


### PR DESCRIPTION
MAC addresses include the letter f and ISC DHCPd allows uppercase letters.