### PR TITLE
Allow choosing the DNS update server

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@ class dhcp (
   Integer[0] $max_lease_time = 86400,
   String $dnskeyname = 'rndc-key',
   Optional[String] $dnsupdatekey = undef,
+  Optional[String] $dnsupdateserver = undef,
   Boolean $omapi = true,
   Optional[String] $omapi_name = undef,
   Optional[String] $omapi_key = undef,
@@ -53,6 +54,8 @@ class dhcp (
   } else {
     $bootp_real = $bootp
   }
+
+  $dnsupdateserver_real = pick($dnsupdateserver, $nameservers[0])
 
   package { $packagename:
     ensure   => installed,

--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -38,7 +38,7 @@ include "<%= @dnsupdatekey %>";
 <% end -%>
 <% @dnsdomain.each do |dom| -%>
 zone <%= dom %>. {
-  primary <%= @nameservers.first %>;
+  primary <%= @dnsupdateserver_real %>;
 <% if @dnsupdatekey and !@dnsupdatekey.empty? -%>
   key <%= @dnskeyname%>;
 <% end -%>


### PR DESCRIPTION
By defaulting to undef the current behaviour is maintained.

Closes GH-88