### PR TITLE
Fixes #20912 - Listen on interfaces in EL7

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,7 @@ fixtures:
   repositories:
     concat:      'https://github.com/puppetlabs/puppetlabs-concat'
     stdlib:      'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+    systemd:     'https://github.com/camptocamp/puppet-systemd'
 
   symlinks:
     dhcp: "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,14 +80,22 @@ class dhcp (
       }
     }
     'RedHat': {
-      file{ '/etc/sysconfig/dhcpd':
-        ensure  => file,
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0644',
-        before  => Package[$packagename],
-        notify  => Service[$servicename],
-        content => template('dhcp/redhat/sysconfig-dhcpd'),
+      if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
+        include ::systemd
+        systemd::dropin_file { 'interfaces.conf':
+          unit    => 'dhcpd.service',
+          content => template('dhcp/redhat/systemd-dropin.conf.erb'),
+        }
+      } else {
+        file { '/etc/sysconfig/dhcpd':
+          ensure  => file,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0644',
+          before  => Package[$packagename],
+          notify  => Service[$servicename],
+          content => template('dhcp/redhat/sysconfig-dhcpd'),
+        }
       }
     }
     /^(FreeBSD|DragonFly)$/: {

--- a/metadata.json
+++ b/metadata.json
@@ -16,6 +16,10 @@
   ],
   "dependencies": [
     {
+      "name": "camptocamp/systemd",
+      "version_requirement": ">= 1.0.0 < 2.0.0"
+    },
+    {
       "name": "puppetlabs/concat",
       "version_requirement": ">= 1.0.0 < 5.0.0"
     },

--- a/spec/classes/failover_spec.rb
+++ b/spec/classes/failover_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'dhcp::failover' do
   on_os_under_test.each do |os, facts|
-    describe "dhcp::failover class on #{os}" do
+    context "on #{os}" do
       let(:pre_condition) {
         "class { '::dhcp': interfaces => ['eth0']}"
       }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -47,6 +47,30 @@ describe 'dhcp' do
         }
 
         it { is_expected.not_to contain_concat__fragment('dhcp.conf+20_includes') }
+
+        if facts[:osfamily] == 'RedHat' && facts[:operatingsystemmajrelease].to_i >= 7
+          it { is_expected.to contain_systemd__dropin_file('interfaces.conf') }
+        else
+          it { is_expected.not_to contain_systemd__dropin_file('interfaces.conf') }
+        end
+
+        if facts[:osfamily] == 'RedHat' && facts[:operatingsystemmajrelease].to_i < 7
+          it { is_expected.to contain_file('/etc/sysconfig/dhcpd') }
+        else
+          it { is_expected.not_to contain_file('/etc/sysconfig/dhcpd') }
+        end
+
+        if facts[:osfamily] == 'Debian'
+          it { is_expected.to contain_file('/etc/default/isc-dhcp-server') }
+        else
+          it { is_expected.not_to contain_file('/etc/default/isc-dhcp-server') }
+        end
+
+        if ['FreeBSD', 'DragonFly'].include?(facts[:osfamily])
+          it { is_expected.to contain_augeas('set listen interfaces') }
+        else
+          it { is_expected.not_to contain_augeas('set listen interfaces') }
+        end
       end
 
       describe "dhcp class parameters on #{os}" do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,359 +2,304 @@ require 'spec_helper'
 
 describe 'dhcp' do
   on_os_under_test.each do |os, facts|
-    conf_path = case os
-                when /^FreeBSD/i
-                  '/usr/local/etc'
-                when /^Archlinux/i
-                  '/etc'
-                else
-                  '/etc/dhcp'
-                end
-    describe "dhcp class without any parameters on #{os}" do
-      let(:params) do {
-        :interfaces => ['eth0'],
-      } end
-
+    context "on #{os}" do
       let(:facts) do
         facts
       end
 
-      it { should compile.with_all_deps }
-
-      it {
-        verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-          'omapi-port 7911;',
-          'default-lease-time 43200;',
-          'max-lease-time 86400;',
-          'ddns-update-style none;',
-          'option domain-name "example.com";',
-          'option domain-name-servers 8.8.8.8, 8.8.4.4;',
-          "option ntp-servers none;",
-          'allow booting;',
-          'allow bootp;',
-          'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-          'option fqdn.rcode2            255;',
-          'option pxegrub code 150 = text ;',
-          'log-facility local7;',
-          "include \"#{conf_path}/dhcpd.hosts\";",
-        ])
-      }
-
-      it { is_expected.not_to contain_concat__fragment('dhcp.conf+20_includes') }
-    end
-
-    describe "dhcp class parameters on #{os}" do
-      let(:params) do {
-        :interfaces   => ['eth0'],
-        :dnsupdatekey => 'mydnsupdatekey',
-        :ntpservers   => ['1.1.1.1', '1.1.1.2'],
-        :omapi_name   => 'mykeyname',
-        :omapi_key    => 'myomapikey',
-        :pxeserver    => '10.0.0.5',
-        :mtu          => 9000,
-        :pxefilename  => 'mypxefilename',
-        :bootfiles    => {
-          '00:00'       => 'pxelinux.0',
-          '00:06'       => 'shim.efi',
-          '00:07'       => 'shim.efi',
-          '00:09'       => 'shim.efi',
-        },
-        :option_static_route => true,
-        :options      => ['provision-url code 224 = text', 'provision-type code 225 = text'],
-        :authoritative => true,
-        :ddns_domainname => 'example.com',
-        :ddns_rev_domainname => 'in-addr.arpa',
-        :includes => ['myinclude1', 'myinclude2'],
-      } end
-
-      let(:facts) do
-        facts
+      let(:params) do
+        {
+          :interfaces => ['eth0'],
+        }.merge(overridden_params)
       end
 
-      it { should compile.with_all_deps }
+      conf_path = case os
+                  when /^FreeBSD/i
+                    '/usr/local/etc'
+                  when /^Archlinux/i
+                    '/etc'
+                  else
+                    '/etc/dhcp'
+                  end
+      describe "dhcp class without any parameters on #{os}" do
+        let(:overridden_params) do {
+        } end
 
-      it {
-        verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-          'omapi-port 7911;',
-          'key mykeyname {',
-          '  algorithm HMAC-MD5;',
-          '  secret "myomapikey";',
-          '}',
-          'omapi-key mykeyname;',
-          'default-lease-time 43200;',
-          'max-lease-time 86400;',
-          'authoritative;',
-          'ddns-updates on;',
-          'ddns-update-style interim;',
-          'update-static-leases on;',
-          'use-host-decl-names on;',
-          'ddns-domainname "example.com";',
-          'ddns-rev-domainname "in-addr.arpa";',
-          'include "mydnsupdatekey";',
-          'zone example.com. {',
-          '  primary 8.8.8.8;',
-          '  key rndc-key;',
-          '}',
-          'option domain-name "example.com";',
-          'option domain-name-servers 8.8.8.8, 8.8.4.4;',
-          'option ntp-servers 1.1.1.1, 1.1.1.2;',
-          'allow booting;',
-          'allow bootp;',
-          'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-          'option fqdn.rcode2            255;',
-          'option pxegrub code 150 = text ;',
-          'option rfc3442-classless-static-routes code 121 = array of integer 8;',
-          'option ms-classless-static-routes code 249 = array of integer 8;',
-          'option interface-mtu 9000;',
-          'option provision-url code 224 = text;',
-          'option provision-type code 225 = text;',
-          'next-server 10.0.0.5;',
-          'option architecture code 93 = unsigned integer 16 ;',
-          'if option architecture = 00:00 {',
-          '  filename "pxelinux.0";',
-          '} elsif option architecture = 00:06 {',
-          '  filename "shim.efi";',
-          '} elsif option architecture = 00:07 {',
-          '  filename "shim.efi";',
-          '} elsif option architecture = 00:09 {',
-          '  filename "shim.efi";',
-          '} else {',
-          '  filename "mypxefilename";',
-          '}',
-          'log-facility local7;',
-          "include \"#{conf_path}/dhcpd.hosts\";",
-        ])
-      }
+        it { should compile.with_all_deps }
 
-      it {
-        verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+20_includes', [
-          'include "myinclude1";',
-          'include "myinclude2";',
-        ])
-      }
-    end
+        it {
+          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
+            'omapi-port 7911;',
+            'default-lease-time 43200;',
+            'max-lease-time 86400;',
+            'ddns-update-style none;',
+            'option domain-name "example.com";',
+            'option domain-name-servers 8.8.8.8, 8.8.4.4;',
+            "option ntp-servers none;",
+            'allow booting;',
+            'allow bootp;',
+            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
+            'option fqdn.rcode2            255;',
+            'option pxegrub code 150 = text ;',
+            'log-facility local7;',
+            "include \"#{conf_path}/dhcpd.hosts\";",
+          ])
+        }
 
-    describe "ddns-updates without key" do
-      let(:params) do {
-        :interfaces => ['eth0'],
-        :ddns_updates => true,
-      } end
-
-      let(:facts) do
-        facts
+        it { is_expected.not_to contain_concat__fragment('dhcp.conf+20_includes') }
       end
 
-      it { should compile.with_all_deps }
+      describe "dhcp class parameters on #{os}" do
+        let(:overridden_params) do {
+          :dnsupdatekey => 'mydnsupdatekey',
+          :ntpservers   => ['1.1.1.1', '1.1.1.2'],
+          :omapi_name   => 'mykeyname',
+          :omapi_key    => 'myomapikey',
+          :pxeserver    => '10.0.0.5',
+          :mtu          => 9000,
+          :pxefilename  => 'mypxefilename',
+          :bootfiles    => {
+            '00:00'       => 'pxelinux.0',
+            '00:06'       => 'shim.efi',
+            '00:07'       => 'shim.efi',
+            '00:09'       => 'shim.efi',
+          },
+          :option_static_route => true,
+          :options      => ['provision-url code 224 = text', 'provision-type code 225 = text'],
+          :authoritative => true,
+          :ddns_domainname => 'example.com',
+          :ddns_rev_domainname => 'in-addr.arpa',
+          :includes => ['myinclude1', 'myinclude2'],
+        } end
 
-      it {
-        verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-          'omapi-port 7911;',
-          'default-lease-time 43200;',
-          'max-lease-time 86400;',
-          'ddns-updates on;',
-          'ddns-update-style interim;',
-          'update-static-leases on;',
-          'use-host-decl-names on;',
-          'zone example.com. {',
-          '  primary 8.8.8.8;',
-          '}',
-          'option domain-name "example.com";',
-          'option domain-name-servers 8.8.8.8, 8.8.4.4;',
-          "option ntp-servers none;",
-          'allow booting;',
-          'allow bootp;',
-          'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-          'option fqdn.rcode2            255;',
-          'option pxegrub code 150 = text ;',
-          'log-facility local7;',
-          "include \"#{conf_path}/dhcpd.hosts\";",
-        ])
-      }
-    end
+        it { should compile.with_all_deps }
 
-    describe "without omapi" do
-      let(:params) do {
-        :interfaces => ['eth0'],
-        :omapi => false,
-      } end
+        it {
+          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
+            'omapi-port 7911;',
+            'key mykeyname {',
+            '  algorithm HMAC-MD5;',
+            '  secret "myomapikey";',
+            '}',
+            'omapi-key mykeyname;',
+            'default-lease-time 43200;',
+            'max-lease-time 86400;',
+            'authoritative;',
+            'ddns-updates on;',
+            'ddns-update-style interim;',
+            'update-static-leases on;',
+            'use-host-decl-names on;',
+            'ddns-domainname "example.com";',
+            'ddns-rev-domainname "in-addr.arpa";',
+            'include "mydnsupdatekey";',
+            'zone example.com. {',
+            '  primary 8.8.8.8;',
+            '  key rndc-key;',
+            '}',
+            'option domain-name "example.com";',
+            'option domain-name-servers 8.8.8.8, 8.8.4.4;',
+            'option ntp-servers 1.1.1.1, 1.1.1.2;',
+            'allow booting;',
+            'allow bootp;',
+            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
+            'option fqdn.rcode2            255;',
+            'option pxegrub code 150 = text ;',
+            'option rfc3442-classless-static-routes code 121 = array of integer 8;',
+            'option ms-classless-static-routes code 249 = array of integer 8;',
+            'option interface-mtu 9000;',
+            'option provision-url code 224 = text;',
+            'option provision-type code 225 = text;',
+            'next-server 10.0.0.5;',
+            'option architecture code 93 = unsigned integer 16 ;',
+            'if option architecture = 00:00 {',
+            '  filename "pxelinux.0";',
+            '} elsif option architecture = 00:06 {',
+            '  filename "shim.efi";',
+            '} elsif option architecture = 00:07 {',
+            '  filename "shim.efi";',
+            '} elsif option architecture = 00:09 {',
+            '  filename "shim.efi";',
+            '} else {',
+            '  filename "mypxefilename";',
+            '}',
+            'log-facility local7;',
+            "include \"#{conf_path}/dhcpd.hosts\";",
+          ])
+        }
 
-      let(:facts) do
-        facts
+          it {
+            verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+20_includes', [
+              'include "myinclude1";',
+              'include "myinclude2";',
+            ])
+          }
       end
 
-      it { should compile.with_all_deps }
+      describe "ddns-updates without key" do
+        let(:overridden_params) do {
+          :ddns_updates => true,
+        } end
 
-      it {
-        verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-          'default-lease-time 43200;',
-          'max-lease-time 86400;',
-          'ddns-update-style none;',
-          'option domain-name "example.com";',
-          'option domain-name-servers 8.8.8.8, 8.8.4.4;',
-          "option ntp-servers none;",
-          'allow booting;',
-          'allow bootp;',
-          'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-          'option fqdn.rcode2            255;',
-          'option pxegrub code 150 = text ;',
-          'log-facility local7;',
-          "include \"#{conf_path}/dhcpd.hosts\";",
-        ])
-      }
-    end
+        it { should compile.with_all_deps }
 
-    describe "without bootp" do
-      let(:params) do {
-        :interfaces => ['eth0'],
-        :bootp => false,
-      } end
-
-      let(:facts) do
-        facts
+        it {
+          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
+            'omapi-port 7911;',
+            'default-lease-time 43200;',
+            'max-lease-time 86400;',
+            'ddns-updates on;',
+            'ddns-update-style interim;',
+            'update-static-leases on;',
+            'use-host-decl-names on;',
+            'zone example.com. {',
+            '  primary 8.8.8.8;',
+            '}',
+            'option domain-name "example.com";',
+            'option domain-name-servers 8.8.8.8, 8.8.4.4;',
+            "option ntp-servers none;",
+            'allow booting;',
+            'allow bootp;',
+            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
+            'option fqdn.rcode2            255;',
+            'option pxegrub code 150 = text ;',
+            'log-facility local7;',
+            "include \"#{conf_path}/dhcpd.hosts\";",
+          ])
+        }
       end
 
-      it { should compile.with_all_deps }
+      describe "without omapi" do
+        let(:overridden_params) do {
+          :omapi => false,
+        } end
 
-      it {
-        verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-          'omapi-port 7911;',
-          'default-lease-time 43200;',
-          'max-lease-time 86400;',
-          'ddns-update-style none;',
-          'option domain-name "example.com";',
-          'option domain-name-servers 8.8.8.8, 8.8.4.4;',
-          "option ntp-servers none;",
-          'allow booting;',
-          'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-          'option fqdn.rcode2            255;',
-          'option pxegrub code 150 = text ;',
-          'log-facility local7;',
-          "include \"#{conf_path}/dhcpd.hosts\";",
-        ])
-      }
-    end
-    describe "without failover, bootp undef" do
-      let(:params) do {
-        :interfaces => ['eth0'],
-      } end
+        it { should compile.with_all_deps }
 
-      let(:facts) do
-        facts
+        it {
+          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
+            'default-lease-time 43200;',
+            'max-lease-time 86400;',
+            'ddns-update-style none;',
+            'option domain-name "example.com";',
+            'option domain-name-servers 8.8.8.8, 8.8.4.4;',
+            "option ntp-servers none;",
+            'allow booting;',
+            'allow bootp;',
+            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
+            'option fqdn.rcode2            255;',
+            'option pxegrub code 150 = text ;',
+            'log-facility local7;',
+            "include \"#{conf_path}/dhcpd.hosts\";",
+          ])
+        }
       end
 
-      it { should compile.with_all_deps }
+      describe "without bootp" do
+        let(:overridden_params) do {
+          :bootp => false,
+        } end
 
-      it {
-        verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-          'omapi-port 7911;',
-          'default-lease-time 43200;',
-          'max-lease-time 86400;',
-          'ddns-update-style none;',
-          'option domain-name "example.com";',
-          'option domain-name-servers 8.8.8.8, 8.8.4.4;',
-          "option ntp-servers none;",
-          'allow booting;',
-          'allow bootp;',
-          'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-          'option fqdn.rcode2            255;',
-          'option pxegrub code 150 = text ;',
-          'log-facility local7;',
-          "include \"#{conf_path}/dhcpd.hosts\";",
-        ])
-      }
-    end
-    describe "with failover, bootp undef" do
-      let(:params) do {
-        :interfaces => ['eth0'],
-        :failover => true
-      } end
+        it { should compile.with_all_deps }
 
-      let(:facts) do
-        facts
+        it {
+          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
+            'omapi-port 7911;',
+            'default-lease-time 43200;',
+            'max-lease-time 86400;',
+            'ddns-update-style none;',
+            'option domain-name "example.com";',
+            'option domain-name-servers 8.8.8.8, 8.8.4.4;',
+            "option ntp-servers none;",
+            'allow booting;',
+            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
+            'option fqdn.rcode2            255;',
+            'option pxegrub code 150 = text ;',
+            'log-facility local7;',
+            "include \"#{conf_path}/dhcpd.hosts\";",
+          ])
+        }
       end
 
-      it { should compile.with_all_deps }
+      describe "with failover, bootp undef" do
+        let(:overridden_params) do {
+          :failover => true
+        } end
 
-      it {
-        verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-          'omapi-port 7911;',
-          'default-lease-time 43200;',
-          'max-lease-time 86400;',
-          'ddns-update-style none;',
-          'option domain-name "example.com";',
-          'option domain-name-servers 8.8.8.8, 8.8.4.4;',
-          "option ntp-servers none;",
-          'allow booting;',
-          'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-          'option fqdn.rcode2            255;',
-          'option pxegrub code 150 = text ;',
-          'log-facility local7;',
-          "include \"#{conf_path}/dhcpd.hosts\";",
-        ])
-      }
-    end
-    describe "with failover, bootp true" do
-      let(:params) do {
-        :interfaces => ['eth0'],
-        :failover => true,
-        :bootp => true
-      } end
+        it { should compile.with_all_deps }
 
-      let(:facts) do
-        facts
+        it {
+          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
+            'omapi-port 7911;',
+            'default-lease-time 43200;',
+            'max-lease-time 86400;',
+            'ddns-update-style none;',
+            'option domain-name "example.com";',
+            'option domain-name-servers 8.8.8.8, 8.8.4.4;',
+            "option ntp-servers none;",
+            'allow booting;',
+            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
+            'option fqdn.rcode2            255;',
+            'option pxegrub code 150 = text ;',
+            'log-facility local7;',
+            "include \"#{conf_path}/dhcpd.hosts\";",
+          ])
+        }
       end
 
-      it { should compile.with_all_deps }
+      describe "with failover, bootp true" do
+        let(:overridden_params) do {
+          :failover => true,
+          :bootp => true
+        } end
 
-      it {
-        verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-          'omapi-port 7911;',
-          'default-lease-time 43200;',
-          'max-lease-time 86400;',
-          'ddns-update-style none;',
-          'option domain-name "example.com";',
-          'option domain-name-servers 8.8.8.8, 8.8.4.4;',
-          "option ntp-servers none;",
-          'allow booting;',
-          'allow bootp;',
-          'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-          'option fqdn.rcode2            255;',
-          'option pxegrub code 150 = text ;',
-          'log-facility local7;',
-          "include \"#{conf_path}/dhcpd.hosts\";",
-        ])
-      }
-    end
-    describe "with failover, bootp false" do
-      let(:params) do {
-        :interfaces => ['eth0'],
-        :failover => true,
-        :bootp => false
-      } end
+        it { should compile.with_all_deps }
 
-      let(:facts) do
-        facts
+        it {
+          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
+            'omapi-port 7911;',
+            'default-lease-time 43200;',
+            'max-lease-time 86400;',
+            'ddns-update-style none;',
+            'option domain-name "example.com";',
+            'option domain-name-servers 8.8.8.8, 8.8.4.4;',
+            "option ntp-servers none;",
+            'allow booting;',
+            'allow bootp;',
+            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
+            'option fqdn.rcode2            255;',
+            'option pxegrub code 150 = text ;',
+            'log-facility local7;',
+            "include \"#{conf_path}/dhcpd.hosts\";",
+          ])
+        }
       end
 
-      it { should compile.with_all_deps }
+      describe "with failover, bootp false" do
+        let(:overridden_params) do {
+          :failover => true,
+          :bootp => false
+        } end
 
-      it {
-        verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-          'omapi-port 7911;',
-          'default-lease-time 43200;',
-          'max-lease-time 86400;',
-          'ddns-update-style none;',
-          'option domain-name "example.com";',
-          'option domain-name-servers 8.8.8.8, 8.8.4.4;',
-          "option ntp-servers none;",
-          'allow booting;',
-          'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-          'option fqdn.rcode2            255;',
-          'option pxegrub code 150 = text ;',
-          'log-facility local7;',
-          "include \"#{conf_path}/dhcpd.hosts\";",
-        ])
-      }
+        it { should compile.with_all_deps }
+
+        it {
+          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
+            'omapi-port 7911;',
+            'default-lease-time 43200;',
+            'max-lease-time 86400;',
+            'ddns-update-style none;',
+            'option domain-name "example.com";',
+            'option domain-name-servers 8.8.8.8, 8.8.4.4;',
+            "option ntp-servers none;",
+            'allow booting;',
+            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
+            'option fqdn.rcode2            255;',
+            'option pxegrub code 150 = text ;',
+            'log-facility local7;',
+            "include \"#{conf_path}/dhcpd.hosts\";",
+          ])
+        }
+      end
     end
   end
 end

--- a/templates/redhat/systemd-dropin.conf.erb
+++ b/templates/redhat/systemd-dropin.conf.erb
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd --no-pid <%= @interfaces.join(' ') %>


### PR DESCRIPTION
https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Networking_Guide/sec-dhcp-configuring-server.html#starting-stopping-server suggests to override the full file but this just uses a drop-in to change as little as possible.