### PR TITLE
Use dhcp_interfaces in the systemd drop

### DIFF
--- a/templates/redhat/systemd-dropin.conf.erb
+++ b/templates/redhat/systemd-dropin.conf.erb
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd --no-pid <%= @interfaces.join(' ') %>
+ExecStart=/usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd --no-pid <%= @dhcp_interfaces.join(' ') %>


### PR DESCRIPTION
By using interfaces we broke support for the $interface parameter.

Closes GH-122