### PR TITLE
Added warning for dhcpd.conf

### DIFF
--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -1,3 +1,11 @@
+#
+# READ: This file is managed by puppet (or foreman-installer) and not by
+# Foreman application. Any updates for Subnets in Foreman database are not
+# reflected in this configuration and vice versa. Configuration updates like
+# DNS servers or adding/removing subnets must be done both in Foreman
+# application and in this configuration preferably via foreman-installer. Use
+# hiera.yaml for multiple subnets.
+#
 # dhcpd.conf
 <% if @omapi -%>
 omapi-port 7911;
@@ -67,6 +75,7 @@ allow bootp;
 
 option fqdn.no-client-update    on;  # set the "O" and "S" flag bits
 option fqdn.rcode2            255;
+
 option pxegrub code 150 = text ;
 
 <% if @option_static_route -%>


### PR DESCRIPTION
This comes up regularly, hopefully this will help few users to figure out why
subnets are not automatically updated when they change it in Foreman DB.