### PR TITLE
Make the config header configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,7 @@ class dhcp (
   Hash[String, Hash] $pools = {},
   Hash[String, Hash] $hosts = {},
   Variant[Array[String], Optional[String]] $includes = undef,
+  String $config_comment = 'dhcpd.conf',
 ) inherits dhcp::params {
 
   # In case people set interface instead of interfaces work around

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -332,6 +332,21 @@ describe 'dhcp' do
           ])
         }
       end
+
+      describe "with config_comment" do
+        context 'with multiple lines' do
+          let(:overridden_params) do {
+            :config_comment => "first line\nsecond line"
+          } end
+
+          it do
+            verify_concat_fragment_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
+              '# first line',
+              '# second line',
+            ])
+          end
+        end
+      end
     end
   end
 end

--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -1,4 +1,6 @@
-# dhcpd.conf
+<% @config_comment.split("\n").each do |line| -%>
+<%= "# #{line}" %>
+<% end -%>
 <% if @omapi -%>
 omapi-port 7911;
 <% if @omapi_name && @omapi_key && !@omapi_key.empty? -%>


### PR DESCRIPTION
This allows the installer to set a specific warning that's tailored to the installer. It won't affect users outside of the installer. It also allows changing the message in a downstream product to include help URLs.

Alternative to https://github.com/theforeman/puppet-dhcp/pull/148