### PR TITLE
Support iPXE without chain-loading

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ class dhcp (
   Optional[String] $omapi_key = undef,
   Optional[String] $pxeserver = undef,
   String $pxefilename = $dhcp::params::pxefilename,
+  Optional[String] $ipxe_filename = undef,
   Optional[Integer[0]] $mtu  = undef,
   Hash[String, String] $bootfiles = $dhcp::params::bootfiles,
   String $logfacility = 'local7',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -76,14 +76,15 @@ describe 'dhcp' do
 
       describe "dhcp class parameters on #{os}" do
         let(:overridden_params) do {
-          :dnsupdatekey => 'mydnsupdatekey',
-          :ntpservers   => ['1.1.1.1', '1.1.1.2'],
-          :omapi_name   => 'mykeyname',
-          :omapi_key    => 'myomapikey',
-          :pxeserver    => '10.0.0.5',
-          :mtu          => 9000,
-          :pxefilename  => 'mypxefilename',
-          :bootfiles    => {
+          :dnsupdatekey  => 'mydnsupdatekey',
+          :ntpservers    => ['1.1.1.1', '1.1.1.2'],
+          :omapi_name    => 'mykeyname',
+          :omapi_key     => 'myomapikey',
+          :pxeserver     => '10.0.0.5',
+          :mtu           => 9000,
+          :pxefilename   => 'mypxefilename',
+          :ipxe_filename => 'myipxefilename',
+          :bootfiles     => {
             '00:00'       => 'pxelinux.0',
             '00:06'       => 'shim.efi',
             '00:07'       => 'shim.efi',
@@ -137,7 +138,9 @@ describe 'dhcp' do
             'option provision-type code 225 = text;',
             'next-server 10.0.0.5;',
             'option architecture code 93 = unsigned integer 16 ;',
-            'if option architecture = 00:00 {',
+            'if exists user-class and option user-class = "iPXE" {',
+            '  filename "myipxefilename";',
+            '} elsif option architecture = 00:00 {',
             '  filename "pxelinux.0";',
             '} elsif option architecture = 00:06 {',
             '  filename "shim.efi";',

--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -94,6 +94,10 @@ next-server <%= @pxeserver %>;
 <% unless @bootfiles.empty?
      bootf = @bootfiles.sort_by { |arch, file| arch } -%>
 option architecture code 93 = unsigned integer 16 ;
+<% if @ipxe_filename -%>
+if exists user-class and option user-class = "iPXE" {
+  filename "<%= @ipxe_filename %>";
+} els<% end -%>
 if option architecture = <%= bootf.first[0] %> {
   filename "<%= bootf.first[1] %>";
 <% if bootf.length > 1 -%>


### PR DESCRIPTION
This commit allow to provide a specific PXE filename when PXE client is
iPXE compliant.

Note: This, consequently, allow to fetch directly boot files through
HTTP.

Source: https://projects.theforeman.org/projects/foreman/wiki/Fetch_boot_files_via_http_instead_of_TFTP