### PR TITLE
Adjust config directory mode to the system defaults

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,7 @@ class dhcp (
   String $logfacility = 'local7',
   Boolean $dhcp_monitor = true,
   Stdlib::Absolutepath $dhcp_dir = $dhcp::params::dhcp_dir,
+  Optional[Stdlib::Filemode] $conf_dir_mode = $dhcp::params::conf_dir_mode,
   String $packagename = $dhcp::params::packagename,
   String $servicename = $dhcp::params::servicename,
   $option_static_route = undef,
@@ -72,7 +73,8 @@ class dhcp (
   }
 
   file { $dhcp_dir:
-    mode    => '0755',
+    group   => $dhcp_root_group,
+    mode    => $conf_dir_mode,
     require => Package[$packagename],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,12 +24,14 @@ class dhcp (
   String $logfacility = 'local7',
   Boolean $dhcp_monitor = true,
   Stdlib::Absolutepath $dhcp_dir = $dhcp::params::dhcp_dir,
+  Boolean $manage_dhcp_dir = $dhcp::params::manage_dhcp_dir,
   Optional[Stdlib::Filemode] $conf_dir_mode = $dhcp::params::conf_dir_mode,
   String $packagename = $dhcp::params::packagename,
   String $servicename = $dhcp::params::servicename,
   $option_static_route = undef,
   Variant[Array[String], Optional[String]] $options = undef,
   Boolean $authoritative = false,
+  String $dhcp_root_user = 'root',
   String $dhcp_root_group = $dhcp::params::root_group,
   Boolean $ddns_updates = false,
   Optional[String] $ddns_domainname = undef,
@@ -72,10 +74,13 @@ class dhcp (
     ensure   => installed,
   }
 
-  file { $dhcp_dir:
-    group   => $dhcp_root_group,
-    mode    => $conf_dir_mode,
-    require => Package[$packagename],
+  if $manage_dhcp_dir {
+    file { $dhcp_dir:
+      owner   => $dhcp_root_user,
+      group   => $dhcp_root_group,
+      mode    => $conf_dir_mode,
+      require => Package[$packagename],
+    }
   }
 
   # Only debian and ubuntu have this style of defaults for startup.
@@ -124,7 +129,7 @@ class dhcp (
   }
 
   concat { "${dhcp_dir}/dhcpd.conf":
-    owner   => 'root',
+    owner   => $dhcp_root_user,
     group   => $dhcp_root_group,
     mode    => '0644',
     require => Package[$packagename],
@@ -146,7 +151,7 @@ class dhcp (
   }
 
   concat { "${dhcp_dir}/dhcpd.hosts":
-    owner   => 'root',
+    owner   => $dhcp_root_user,
     group   => $dhcp_root_group,
     mode    => '0644',
     require => Package[$packagename],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class dhcp::params {
   case $facts['os']['family'] {
     'Debian': {
       $dhcp_dir = '/etc/dhcp'
+      $manage_dhcp_dir = true
       $conf_dir_mode = '0750'
       $packagename = 'isc-dhcp-server'
       $servicename = 'isc-dhcp-server'
@@ -25,6 +26,7 @@ class dhcp::params {
 
     /^(FreeBSD|DragonFly)$/: {
       $dhcp_dir    = '/usr/local/etc'
+      $manage_dhcp_dir = false
       $conf_dir_mode = undef
       $packagename = 'isc-dhcp44-server'
       $servicename = 'isc-dhcpd'
@@ -34,6 +36,7 @@ class dhcp::params {
 
     'Archlinux': {
       $dhcp_dir    = '/etc'
+      $manage_dhcp_dir = false
       $conf_dir_mode = undef
       $packagename = 'dhcp'
       $servicename = 'dhcpd4'
@@ -43,6 +46,7 @@ class dhcp::params {
 
     'RedHat': {
       $dhcp_dir    = '/etc/dhcp'
+      $manage_dhcp_dir = true
       $conf_dir_mode = '0750'
       if versioncmp($facts['os']['release']['major'], '8') >= 0 {
         $packagename = 'dhcp-server'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,11 +11,12 @@ class dhcp::params {
 
   case $facts['os']['family'] {
     'Debian': {
-      $dhcp_dir    = '/etc/dhcp'
+      $dhcp_dir = '/etc/dhcp'
+      $conf_dir_mode = '0750'
       $packagename = 'isc-dhcp-server'
       $servicename = 'isc-dhcp-server'
-      $root_group  = 'root'
-      $bootfiles   = {
+      $root_group = 'root'
+      $bootfiles = {
         '00:06' => 'grub2/bootia32.efi',
         '00:07' => 'grub2/bootx64.efi',
         '00:09' => 'grub2/bootx64.efi',
@@ -24,6 +25,7 @@ class dhcp::params {
 
     /^(FreeBSD|DragonFly)$/: {
       $dhcp_dir    = '/usr/local/etc'
+      $conf_dir_mode = undef
       $packagename = 'isc-dhcp44-server'
       $servicename = 'isc-dhcpd'
       $root_group  = 'wheel'
@@ -32,6 +34,7 @@ class dhcp::params {
 
     'Archlinux': {
       $dhcp_dir    = '/etc'
+      $conf_dir_mode = undef
       $packagename = 'dhcp'
       $servicename = 'dhcpd4'
       $root_group  = 'root'
@@ -40,6 +43,7 @@ class dhcp::params {
 
     'RedHat': {
       $dhcp_dir    = '/etc/dhcp'
+      $conf_dir_mode = '0750'
       if versioncmp($facts['os']['release']['major'], '8') >= 0 {
         $packagename = 'dhcp-server'
       } else {


### PR DESCRIPTION
We should not change the system defaults for config directory mode, if not asked by user.
We can although manage a group owner of the directory if asked to do so by user.
We at the same time don't need to manage a directory if it's not dhcp specific.