### PR TITLE
Fix default conf_dir mode for Debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@ class dhcp::params {
     'Debian': {
       $dhcp_dir = '/etc/dhcp'
       $manage_dhcp_dir = true
-      $conf_dir_mode = '0750'
+      $conf_dir_mode = '0755'
       $packagename = 'isc-dhcp-server'
       $servicename = 'isc-dhcp-server'
       $root_group = 'root'


### PR DESCRIPTION
In d237525bad20e7267a37d8792a52b4af5aece4f1 we have falsely introduced 0750 as default for Debian.