### PR TITLE
add support for client-updates instruction for interim DDNS.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,7 @@ class dhcp (
   Optional[String] $ddns_domainname = undef,
   Optional[String] $ddns_rev_domainname = undef,
   Enum['none', 'interim', 'standard'] $ddns_update_style = 'interim',
+  Optional[Boolean] $client_updates = undef,
   Hash[String, Hash] $pools = {},
   Hash[String, Hash] $hosts = {},
   Variant[Array[String], Optional[String]] $includes = undef,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -205,6 +205,44 @@ describe 'dhcp' do
         }
       end
 
+      describe "with ddns-updates and client-updates ignored" do
+        let(:params) do
+          super().merge(
+            ddns_updates: true,
+            client_updates: false,
+            dnsupdateserver: '127.1.2.3',
+          )
+        end
+
+        it { should compile.with_all_deps }
+
+        it {
+          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
+            'omapi-port 7911;',
+            'default-lease-time 43200;',
+            'max-lease-time 86400;',
+            'not authoritative;',
+            'ddns-updates on;',
+            'ddns-update-style interim;',
+            'update-static-leases on;',
+            'use-host-decl-names on;',
+            'ignore client-updates;',
+            'zone example.com. {',
+            '  primary 127.1.2.3;',
+            '}',
+            'option domain-name "example.com";',
+            "option ntp-servers none;",
+            'allow booting;',
+            'allow bootp;',
+            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
+            'option fqdn.rcode2            255;',
+            'option pxegrub code 150 = text ;',
+            'log-facility local7;',
+            "include \"#{conf_path}/dhcpd.hosts\";",
+          ])
+        }
+      end
+
       describe "without omapi" do
         let(:params) { super().merge(omapi: false) }
 

--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -28,6 +28,11 @@ ddns-updates on;
 ddns-update-style <%= @ddns_update_style %>;
 update-static-leases on;
 use-host-decl-names on;
+<% if @client_updates == true -%>
+allow client-updates;
+<% elsif @client_updates == false -%>
+ignore client-updates;
+<% end -%>
 
 <% if @ddns_domainname and !@ddns_domainname.empty? -%>
 ddns-domainname "<%= @ddns_domainname %>";


### PR DESCRIPTION
when using the *interim* update style for DDNS, clients can choose
to update their own A record. this options instructs the server
to ignore that request and update both the PTR and A records.