### PR TITLE
Mark compatible with camptocamp/systemd 3

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
   "dependencies": [
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 1.0.0 < 3.0.0"
+      "version_requirement": ">= 1.0.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
The breaking changes do not affect this module and allows Puppet 7 compatibility.