### PR TITLE
remove unnecessary usage of concat spec helper methods

### DIFF
--- a/spec/classes/failover_spec.rb
+++ b/spec/classes/failover_spec.rb
@@ -17,23 +17,33 @@ describe 'dhcp::failover' do
         facts
       end
 
+      let(:fragment_name) do
+        'dhcp.conf+10_failover.dhcp'
+      end
+
+      let(:expected_content) do
+        <<~CONTENT
+          # failover
+          failover peer "dhcp-failover" {
+            primary;
+            address 10.1.1.10;
+            port 519;
+            peer address 10.1.1.20;
+            peer port 519;
+            max-response-delay 30;
+            max-unacked-updates 10;
+            load balance max seconds 3;
+            mclt 300;
+            split 128;
+          }
+        CONTENT
+      end
+
       it { should compile.with_all_deps }
 
-      it {
-        verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+10_failover.dhcp', [
-          'failover peer "dhcp-failover" {',
-          '  primary;',
-          '  address 10.1.1.10;',
-          '  port 519;',
-          '  peer address 10.1.1.20;',
-          '  peer port 519;',
-          '  max-response-delay 30;',
-          '  max-unacked-updates 10;',
-          '  load balance max seconds 3;',
-          '  mclt 300;', '  split 128;',
-          '}'
-        ])
-      }
+      it do
+        is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+      end
     end
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe 'dhcp' do
+  let(:fragment_name) do
+    'dhcp.conf+01_main.dhcp'
+  end
+
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) { override_facts(facts, networking: {domain: 'example.com'}) }
@@ -23,26 +27,45 @@ describe 'dhcp' do
       end
 
       describe "without any parameters" do
+        let(:expected_content) do
+          <<~CONTENT
+            # dhcpd.conf
+            omapi-port 7911;
+
+            default-lease-time 43200;
+            max-lease-time 86400;
+
+
+            not authoritative;
+
+
+            ddns-update-style none;
+
+            option domain-name "example.com";
+            option ntp-servers none;
+
+            allow booting;
+            allow bootp;
+
+            option fqdn.no-client-update    on;  # set the "O" and "S" flag bits
+            option fqdn.rcode2            255;
+            option pxegrub code 150 = text ;
+
+
+
+
+
+            log-facility local7;
+
+            include "#{conf_path}/dhcpd.hosts";
+          CONTENT
+        end
+
         it { should compile.with_all_deps }
 
-        it {
-          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-            'omapi-port 7911;',
-            'default-lease-time 43200;',
-            'max-lease-time 86400;',
-            'not authoritative;',
-            'ddns-update-style none;',
-            'option domain-name "example.com";',
-            "option ntp-servers none;",
-            'allow booting;',
-            'allow bootp;',
-            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-            'option fqdn.rcode2            255;',
-            'option pxegrub code 150 = text ;',
-            'log-facility local7;',
-            "include \"#{conf_path}/dhcpd.hosts\";",
-          ])
-        }
+        it do
+          is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+        end
 
         it { is_expected.not_to contain_concat__fragment('dhcp.conf+20_includes') }
 
@@ -99,73 +122,99 @@ describe 'dhcp' do
           )
         end
 
+        let(:expected_content) do
+          <<~CONTENT
+            # dhcpd.conf
+            omapi-port 7911;
+            key mykeyname {
+              algorithm HMAC-MD5;
+              secret "myomapikey";
+            }
+            omapi-key mykeyname;
+
+            default-lease-time 43200;
+            max-lease-time 86400;
+
+            # Make the server authoritative for the network segments that
+            # are configured, and tell it to send DHCPNAKs to bogus requests
+            authoritative;
+
+            ddns-updates on;
+            ddns-update-style standard;
+            update-static-leases on;
+            use-host-decl-names on;
+
+            ddns-domainname "example.com";
+            ddns-rev-domainname "in-addr.arpa";
+
+            # Key from bind
+            include "mydnsupdatekey";
+            zone example.com. {
+              primary 8.8.8.8;
+              key rndc-key;
+            }
+
+            option domain-name "example.com";
+            option domain-name-servers 8.8.8.8, 8.8.4.4;
+            option ntp-servers 1.1.1.1, 1.1.1.2;
+
+            allow booting;
+            allow bootp;
+
+            option fqdn.no-client-update    on;  # set the "O" and "S" flag bits
+            option fqdn.rcode2            255;
+            option pxegrub code 150 = text ;
+
+            option rfc3442-classless-static-routes code 121 = array of integer 8;
+            option ms-classless-static-routes code 249 = array of integer 8;
+
+            option interface-mtu 9000;
+
+            option provision-url code 224 = text;
+            option provision-type code 225 = text;
+
+            # required for UEFI HTTP boot
+            if substring(option vendor-class-identifier, 0, 10) = "HTTPClient" {
+              option vendor-class-identifier "HTTPClient";
+            }
+            # promote vendor in dhcpd.leases
+            set vendor-string = option vendor-class-identifier;
+            # next server and filename options
+            next-server 10.0.0.5;
+            option architecture code 93 = unsigned integer 16 ;
+            if exists user-class and option user-class = "iPXE" {
+              filename "myipxefilename";
+            } elsif option architecture = 00:00 {
+              filename "pxelinux.0";
+            } elsif option architecture = 00:06 {
+              filename "shim.efi";
+            } elsif option architecture = 00:07 {
+              filename "shim.efi";
+            } elsif option architecture = 00:09 {
+              filename "shim.efi";
+            } else {
+              filename "mypxefilename";
+            }
+
+            log-facility local7;
+
+            include "#{conf_path}/dhcpd.hosts";
+          CONTENT
+        end
+
         it { should compile.with_all_deps }
 
-        it {
-          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-            'omapi-port 7911;',
-            'key mykeyname {',
-            '  algorithm HMAC-MD5;',
-            '  secret "myomapikey";',
-            '}',
-            'omapi-key mykeyname;',
-            'default-lease-time 43200;',
-            'max-lease-time 86400;',
-            'authoritative;',
-            'ddns-updates on;',
-            'ddns-update-style standard;',
-            'update-static-leases on;',
-            'use-host-decl-names on;',
-            'ddns-domainname "example.com";',
-            'ddns-rev-domainname "in-addr.arpa";',
-            'include "mydnsupdatekey";',
-            'zone example.com. {',
-            '  primary 8.8.8.8;',
-            '  key rndc-key;',
-            '}',
-            'option domain-name "example.com";',
-            'option domain-name-servers 8.8.8.8, 8.8.4.4;',
-            'option ntp-servers 1.1.1.1, 1.1.1.2;',
-            'allow booting;',
-            'allow bootp;',
-            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-            'option fqdn.rcode2            255;',
-            'option pxegrub code 150 = text ;',
-            'option rfc3442-classless-static-routes code 121 = array of integer 8;',
-            'option ms-classless-static-routes code 249 = array of integer 8;',
-            'option interface-mtu 9000;',
-            'option provision-url code 224 = text;',
-            'option provision-type code 225 = text;',
-            'if substring(option vendor-class-identifier, 0, 10) = "HTTPClient" {',
-            '  option vendor-class-identifier "HTTPClient";',
-            '}',
-            'set vendor-string = option vendor-class-identifier;',
-            'next-server 10.0.0.5;',
-            'option architecture code 93 = unsigned integer 16 ;',
-            'if exists user-class and option user-class = "iPXE" {',
-            '  filename "myipxefilename";',
-            '} elsif option architecture = 00:00 {',
-            '  filename "pxelinux.0";',
-            '} elsif option architecture = 00:06 {',
-            '  filename "shim.efi";',
-            '} elsif option architecture = 00:07 {',
-            '  filename "shim.efi";',
-            '} elsif option architecture = 00:09 {',
-            '  filename "shim.efi";',
-            '} else {',
-            '  filename "mypxefilename";',
-            '}',
-            'log-facility local7;',
-            "include \"#{conf_path}/dhcpd.hosts\";",
-          ])
-        }
+        it do
+          is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+        end
 
-        it {
-          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+20_includes', [
-            'include "myinclude1";',
-            'include "myinclude2";',
-          ])
-        }
+        it do
+          is_expected.to contain_concat__fragment('dhcp.conf+20_includes')
+            .with_content(<<~CONTENT)
+              include "myinclude1";
+              include "myinclude2";
+            CONTENT
+        end
       end
 
       describe "with ddns-updates without key" do
@@ -178,31 +227,52 @@ describe 'dhcp' do
 
         it { should compile.with_all_deps }
 
-        it {
-          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-            'omapi-port 7911;',
-            'default-lease-time 43200;',
-            'max-lease-time 86400;',
-            'not authoritative;',
-            'ddns-updates on;',
-            'ddns-update-style interim;',
-            'update-static-leases on;',
-            'use-host-decl-names on;',
-            'zone example.com. {',
-            '  primary 8.8.8.8;',
-            '}',
-            'option domain-name "example.com";',
-            'option domain-name-servers 8.8.8.8, 8.8.4.4;',
-            "option ntp-servers none;",
-            'allow booting;',
-            'allow bootp;',
-            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-            'option fqdn.rcode2            255;',
-            'option pxegrub code 150 = text ;',
-            'log-facility local7;',
-            "include \"#{conf_path}/dhcpd.hosts\";",
-          ])
-        }
+        let(:expected_content) do
+          <<~CONTENT
+            # dhcpd.conf
+            omapi-port 7911;
+
+            default-lease-time 43200;
+            max-lease-time 86400;
+
+
+            not authoritative;
+
+            ddns-updates on;
+            ddns-update-style interim;
+            update-static-leases on;
+            use-host-decl-names on;
+
+
+            # Key from bind
+            zone example.com. {
+              primary 8.8.8.8;
+            }
+
+            option domain-name "example.com";
+            option domain-name-servers 8.8.8.8, 8.8.4.4;
+            option ntp-servers none;
+
+            allow booting;
+            allow bootp;
+
+            option fqdn.no-client-update    on;  # set the "O" and "S" flag bits
+            option fqdn.rcode2            255;
+            option pxegrub code 150 = text ;
+
+
+
+
+
+            log-facility local7;
+
+            include "#{conf_path}/dhcpd.hosts";
+          CONTENT
+        end
+
+        it do
+          is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+        end
       end
 
       describe "with ddns-updates and client-updates ignored" do
@@ -214,57 +284,97 @@ describe 'dhcp' do
           )
         end
 
+        let(:expected_content) do
+          <<~CONTENT
+            # dhcpd.conf
+            omapi-port 7911;
+
+            default-lease-time 43200;
+            max-lease-time 86400;
+
+
+            not authoritative;
+
+            ddns-updates on;
+            ddns-update-style interim;
+            update-static-leases on;
+            use-host-decl-names on;
+            ignore client-updates;
+
+
+            # Key from bind
+            zone example.com. {
+              primary 127.1.2.3;
+            }
+
+            option domain-name "example.com";
+            option ntp-servers none;
+
+            allow booting;
+            allow bootp;
+
+            option fqdn.no-client-update    on;  # set the "O" and "S" flag bits
+            option fqdn.rcode2            255;
+            option pxegrub code 150 = text ;
+
+
+
+
+
+            log-facility local7;
+
+            include "#{conf_path}/dhcpd.hosts";
+          CONTENT
+        end
+
         it { should compile.with_all_deps }
 
-        it {
-          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-            'omapi-port 7911;',
-            'default-lease-time 43200;',
-            'max-lease-time 86400;',
-            'not authoritative;',
-            'ddns-updates on;',
-            'ddns-update-style interim;',
-            'update-static-leases on;',
-            'use-host-decl-names on;',
-            'ignore client-updates;',
-            'zone example.com. {',
-            '  primary 127.1.2.3;',
-            '}',
-            'option domain-name "example.com";',
-            "option ntp-servers none;",
-            'allow booting;',
-            'allow bootp;',
-            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-            'option fqdn.rcode2            255;',
-            'option pxegrub code 150 = text ;',
-            'log-facility local7;',
-            "include \"#{conf_path}/dhcpd.hosts\";",
-          ])
-        }
+        it do
+          is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+        end
       end
 
       describe "without omapi" do
         let(:params) { super().merge(omapi: false) }
 
+        let(:expected_content) do
+          <<~CONTENT
+            # dhcpd.conf
+
+            default-lease-time 43200;
+            max-lease-time 86400;
+
+
+            not authoritative;
+
+
+            ddns-update-style none;
+
+            option domain-name "example.com";
+            option ntp-servers none;
+
+            allow booting;
+            allow bootp;
+
+            option fqdn.no-client-update    on;  # set the "O" and "S" flag bits
+            option fqdn.rcode2            255;
+            option pxegrub code 150 = text ;
+
+
+
+
+
+            log-facility local7;
+
+            include "#{conf_path}/dhcpd.hosts";
+          CONTENT
+        end
+
         it { should compile.with_all_deps }
 
-        it {
-          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-            'default-lease-time 43200;',
-            'max-lease-time 86400;',
-            'not authoritative;',
-            'ddns-update-style none;',
-            'option domain-name "example.com";',
-            "option ntp-servers none;",
-            'allow booting;',
-            'allow bootp;',
-            'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-            'option fqdn.rcode2            255;',
-            'option pxegrub code 150 = text ;',
-            'log-facility local7;',
-            "include \"#{conf_path}/dhcpd.hosts\";",
-          ])
-        }
+        it do
+          is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+        end
       end
 
       describe "without bootp" do
@@ -278,74 +388,131 @@ describe 'dhcp' do
         let(:params) { super().merge(failover: true) }
 
         describe "and bootp undef" do
+          let(:expected_content) do
+            <<~CONTENT
+              # dhcpd.conf
+              omapi-port 7911;
+
+              default-lease-time 43200;
+              max-lease-time 86400;
+
+
+              not authoritative;
+
+
+              ddns-update-style none;
+
+              option domain-name "example.com";
+              option ntp-servers none;
+
+              allow booting;
+
+              option fqdn.no-client-update    on;  # set the "O" and "S" flag bits
+              option fqdn.rcode2            255;
+              option pxegrub code 150 = text ;
+
+
+
+
+
+              log-facility local7;
+
+              include "#{conf_path}/dhcpd.hosts";
+            CONTENT
+          end
+
           it { should compile.with_all_deps }
 
-          it {
-            verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-              'omapi-port 7911;',
-              'default-lease-time 43200;',
-              'max-lease-time 86400;',
-              'not authoritative;',
-              'ddns-update-style none;',
-              'option domain-name "example.com";',
-              "option ntp-servers none;",
-              'allow booting;',
-              'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-              'option fqdn.rcode2            255;',
-              'option pxegrub code 150 = text ;',
-              'log-facility local7;',
-              "include \"#{conf_path}/dhcpd.hosts\";",
-            ])
-          }
+          it do
+            is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+          end
         end
 
         describe "and bootp true" do
           let(:params) { super().merge(bootp: true) }
 
+          let(:expected_content) do
+            <<~CONTENT
+              # dhcpd.conf
+              omapi-port 7911;
+
+              default-lease-time 43200;
+              max-lease-time 86400;
+
+
+              not authoritative;
+
+
+              ddns-update-style none;
+
+              option domain-name "example.com";
+              option ntp-servers none;
+
+              allow booting;
+              allow bootp;
+
+              option fqdn.no-client-update    on;  # set the "O" and "S" flag bits
+              option fqdn.rcode2            255;
+              option pxegrub code 150 = text ;
+
+
+
+
+
+              log-facility local7;
+
+              include "#{conf_path}/dhcpd.hosts";
+            CONTENT
+          end
+
           it { should compile.with_all_deps }
 
-          it {
-            verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-              'omapi-port 7911;',
-              'default-lease-time 43200;',
-              'max-lease-time 86400;',
-              'not authoritative;',
-              'ddns-update-style none;',
-              'option domain-name "example.com";',
-              "option ntp-servers none;",
-              'allow booting;',
-              'allow bootp;',
-              'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-              'option fqdn.rcode2            255;',
-              'option pxegrub code 150 = text ;',
-              'log-facility local7;',
-              "include \"#{conf_path}/dhcpd.hosts\";",
-            ])
-          }
+          it do
+            is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+          end
         end
 
         describe "and bootp false" do
           let(:params) { super().merge(bootp: false) }
 
+          let(:expected_content) do
+            <<~CONTENT
+              # dhcpd.conf
+              omapi-port 7911;
+
+              default-lease-time 43200;
+              max-lease-time 86400;
+
+
+              not authoritative;
+
+
+              ddns-update-style none;
+
+              option domain-name "example.com";
+              option ntp-servers none;
+
+              allow booting;
+
+              option fqdn.no-client-update    on;  # set the "O" and "S" flag bits
+              option fqdn.rcode2            255;
+              option pxegrub code 150 = text ;
+
+
+
+
+
+              log-facility local7;
+
+              include "#{conf_path}/dhcpd.hosts";
+            CONTENT
+          end
+
           it { should compile.with_all_deps }
 
-          it {
-            verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-              'omapi-port 7911;',
-              'default-lease-time 43200;',
-              'max-lease-time 86400;',
-              'not authoritative;',
-              'ddns-update-style none;',
-              'option domain-name "example.com";',
-              "option ntp-servers none;",
-              'allow booting;',
-              'option fqdn.no-client-update    on;  # set the "O" and "S" flag bits',
-              'option fqdn.rcode2            255;',
-              'option pxegrub code 150 = text ;',
-              'log-facility local7;',
-              "include \"#{conf_path}/dhcpd.hosts\";",
-            ])
-          }
+          it do
+            is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+          end
         end
       end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -520,11 +520,16 @@ describe 'dhcp' do
         context 'with multiple lines' do
           let(:params) { super().merge(config_comment: "first line\nsecond line") }
 
+          let(:expected_content) do
+            /#{<<~CONTENT}/m
+              # first line
+              # second line
+              .*
+            CONTENT
+          end
+
           it do
-            verify_concat_fragment_contents(catalogue, 'dhcp.conf+01_main.dhcp', [
-              '# first line',
-              '# second line',
-            ])
+            is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
           end
         end
       end

--- a/spec/defines/class_spec.rb
+++ b/spec/defines/class_spec.rb
@@ -19,13 +19,25 @@ describe 'dhcp::dhcp_class' do
         "class { '::dhcp': interfaces => ['eth0']}"
       end
 
-      it {
-        verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+50_vendor-class.dhcp', [
-          'class "vendor-class" {',
-          '  match option vendor-class-identifier;',
-          '}'
-        ])
-      }
+      let(:fragment_name) do
+        'dhcp.conf+50_vendor-class.dhcp'
+      end
+
+      let(:expected_content) do
+        <<~CONTENT
+          #################################
+          # class vendor-class
+          #################################
+          class "vendor-class" {
+            match option vendor-class-identifier;
+          }
+
+        CONTENT
+      end
+
+      it do
+        is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+      end
     end
   end
 end

--- a/spec/defines/host_spec.rb
+++ b/spec/defines/host_spec.rb
@@ -19,15 +19,23 @@ describe 'dhcp::host' do
           "class { '::dhcp': interfaces => ['eth0']}"
         end
 
-        it {
-          verify_concat_fragment_exact_contents(catalogue, 'dhcp.hosts+10_myhost.hosts', [
-            'host myhost {',
-            '  hardware ethernet   01:02:03:04:05:06;',
-            '  fixed-address       10.0.0.100;',
-            '  ddns-hostname       "myhost";',
-            '}',
-          ])
-        }
+        let(:fragment_name) do
+          'dhcp.hosts+10_myhost.hosts'
+        end
+
+        let(:expected_content) do
+          <<~CONTENT
+            host myhost {
+              hardware ethernet   01:02:03:04:05:06;
+              fixed-address       10.0.0.100;
+              ddns-hostname       "myhost";
+            }
+          CONTENT
+        end
+
+        it do
+          is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+        end
       end
     end
   end

--- a/spec/defines/pool_spec.rb
+++ b/spec/defines/pool_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe 'dhcp::pool' do
+  let(:fragment_name) do
+    'dhcp.conf+70_mypool.dhcp'
+  end
+
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let :title do 'mypool' end
@@ -19,13 +23,19 @@ describe 'dhcp::pool' do
           :mask    => '255.255.255.0',
         } end
 
-        it {
-          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+70_mypool.dhcp', [
-            "subnet 10.0.0.0 netmask 255.255.255.0 {",
-            "  option subnet-mask 255.255.255.0;",
-            "}",
-          ])
-        }
+        let(:expected_content) do
+          <<~CONTENT
+            # mypool
+            subnet 10.0.0.0 netmask 255.255.255.0 {
+
+              option subnet-mask 255.255.255.0;
+            }
+          CONTENT
+        end
+
+        it do
+          is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+        end
       end
 
       describe 'with failover' do
@@ -36,18 +46,24 @@ describe 'dhcp::pool' do
           :failover => '10.1.1.20',
         } end
 
-        it {
-          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+70_mypool.dhcp', [
-            'subnet 10.0.0.0 netmask 255.255.255.0 {',
-            '  pool',
-            '  {',
-            '    failover peer "10.1.1.20";',
-            '    range 10.0.0.10 10.0.0.50;',
-            '  }',
-            '  option subnet-mask 255.255.255.0;',
-            '}',
-          ])
-        }
+        let(:expected_content) do
+          <<~CONTENT
+            # mypool
+            subnet 10.0.0.0 netmask 255.255.255.0 {
+              pool
+              {
+                failover peer "10.1.1.20";
+                range 10.0.0.10 10.0.0.50;
+              }
+
+              option subnet-mask 255.255.255.0;
+            }
+          CONTENT
+        end
+
+        it do
+          is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+        end
       end
 
       describe 'with empty string range' do
@@ -57,13 +73,19 @@ describe 'dhcp::pool' do
           :range   => '',
         } end
 
-        it {
-          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+70_mypool.dhcp', [
-            "subnet 10.0.0.0 netmask 255.255.255.0 {",
-            "  option subnet-mask 255.255.255.0;",
-            "}",
-          ])
-        }
+        let(:expected_content) do
+          <<~CONTENT
+            # mypool
+            subnet 10.0.0.0 netmask 255.255.255.0 {
+
+              option subnet-mask 255.255.255.0;
+            }
+          CONTENT
+        end
+
+        it do
+          is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+        end
       end
 
       describe 'with range array' do
@@ -73,18 +95,24 @@ describe 'dhcp::pool' do
           :range   => ['10.0.0.10 10.0.0.50','10.0.0.100 10.0.0.150'],
         } end
 
-        it {
-          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+70_mypool.dhcp', [
-            'subnet 10.0.0.0 netmask 255.255.255.0 {',
-            '  pool',
-            '  {',
-            '    range 10.0.0.10 10.0.0.50;',
-            '    range 10.0.0.100 10.0.0.150;',
-            '  }',
-            '  option subnet-mask 255.255.255.0;',
-            '}',
-          ])
-        }
+        let(:expected_content) do
+          <<~CONTENT
+            # mypool
+            subnet 10.0.0.0 netmask 255.255.255.0 {
+              pool
+              {
+                range 10.0.0.10 10.0.0.50;
+                range 10.0.0.100 10.0.0.150;
+              }
+
+              option subnet-mask 255.255.255.0;
+            }
+          CONTENT
+        end
+
+        it do
+          is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+        end
       end
 
       describe 'with search_domains string' do
@@ -94,14 +122,20 @@ describe 'dhcp::pool' do
           :search_domains => 'example.org, other.example.org'
         } end
 
-        it {
-          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+70_mypool.dhcp', [
-            'subnet 10.0.0.0 netmask 255.255.255.0 {',
-            '  option subnet-mask 255.255.255.0;',
-            '  option domain-search "example.org", "other.example.org";',
-            '}',
-          ])
-        }
+        let(:expected_content) do
+          <<~CONTENT
+            # mypool
+            subnet 10.0.0.0 netmask 255.255.255.0 {
+
+              option subnet-mask 255.255.255.0;
+              option domain-search "example.org", "other.example.org";
+            }
+          CONTENT
+        end
+
+        it do
+          is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+        end
       end
 
       describe 'full parameters' do
@@ -125,31 +159,39 @@ describe 'dhcp::pool' do
         :raw_prepend      => 'example prepend;',
         } end
 
-        it {
-          verify_concat_fragment_exact_contents(catalogue, 'dhcp.conf+70_mypool.dhcp', [
-            "subnet 10.0.0.0 netmask 255.255.255.0 {",
-            "  example prepend;",
-            "  pool",
-            "  {",
-            "    allow members of \"some-class\";",
-            "    range 10.0.0.10 10.0.0.50;",
-            "  }",
-            "  option domain-name \"example.org\";",
-            "  option subnet-mask 255.255.255.0;",
-            "  option routers 10.0.0.1;",
-            "  option rfc3442-classless-static-routes 24, 10, 0, 1, 0, 10, 0, 0, 2, 0, 10, 0, 0, 1;",
-            "  option ms-classless-static-routes 24, 10, 0, 1, 0, 10, 0, 0, 2, 0, 10, 0, 0, 1;",
-            "  option ntp-servers 10.0.0.2;",
-            "  max-lease-time 300;",
-            "  option domain-name-servers 10.0.0.2, 10.0.0.4;",
-            "  option domain-search \"example.org\", \"other.example.org\";",
-            "  option interface-mtu 9000;",
-            "  next-server 10.0.0.2;",
-            "  filename \"pxelinux.0\";",
-            "  example append;",
-            "}",
-          ])
-        }
+        let(:expected_content) do
+          <<~CONTENT
+            # mypool
+            subnet 10.0.0.0 netmask 255.255.255.0 {
+
+              example prepend;
+              pool
+              {
+                allow members of "some-class";
+                range 10.0.0.10 10.0.0.50;
+              }
+
+              option domain-name "example.org";
+              option subnet-mask 255.255.255.0;
+              option routers 10.0.0.1;
+              option rfc3442-classless-static-routes 24, 10, 0, 1, 0, 10, 0, 0, 2, 0, 10, 0, 0, 1;
+              option ms-classless-static-routes 24, 10, 0, 1, 0, 10, 0, 0, 2, 0, 10, 0, 0, 1;
+              option ntp-servers 10.0.0.2;
+              max-lease-time 300;
+              option domain-name-servers 10.0.0.2, 10.0.0.4;
+              option domain-search "example.org", "other.example.org";
+              option interface-mtu 9000;
+              next-server 10.0.0.2;
+              filename "pxelinux.0";
+
+              example append;
+            }
+          CONTENT
+        end
+
+        it do
+          is_expected.to contain_concat__fragment(fragment_name).with_content(expected_content)
+        end
       end
     end
   end


### PR DESCRIPTION
Per discussion in #193, these helper methods should be removed.  Care was taken not to obscure the odd whitespace in several of the ERB templates by matching with regular expressions, in case it is desirable to cleanup the templates in the future.