### PR TITLE
Drop Debian 8 support and update default template

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -68,7 +68,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8",
         "9",
         "10"
       ]

--- a/templates/debian/default_isc-dhcp-server
+++ b/templates/debian/default_isc-dhcp-server
@@ -1,11 +1,18 @@
-# Defaults for dhcp initscript
-# sourced by /etc/init.d/dhcp
-# installed at /etc/default/isc-dhcp-server by the maintainer scripts
+# Defaults for isc-dhcp-server (sourced by /etc/init.d/isc-dhcp-server)
 
-#
-# This is a POSIX shell fragment
-#
+# Path to dhcpd's config file (default: /etc/dhcp/dhcpd.conf).
+DHCPDv4_CONF=<%= @dhcp_dir %>/dhcpd.conf
+#DHCPDv6_CONF=/etc/dhcp/dhcpd6.conf
+
+# Path to dhcpd's PID file (default: /var/run/dhcpd.pid).
+#DHCPDv4_PID=/var/run/dhcpd.pid
+#DHCPDv6_PID=/var/run/dhcpd6.pid
+
+# Additional options to start dhcpd with.
+#	Don't use options -cf or -pf here; use DHCPD_CONF/ DHCPD_PID instead
+#OPTIONS=""
 
 # On what interfaces should the DHCP server (dhcpd) serve DHCP requests?
-#       Separate multiple interfaces with spaces, e.g. "eth0 eth1".
-INTERFACES="<%= @dhcp_interfaces.join(' ') %>"
+#	Separate multiple interfaces with spaces, e.g. "eth0 eth1".
+INTERFACESv4="<%= @dhcp_interfaces.join(' ') %>"
+INTERFACESv6=""


### PR DESCRIPTION
The primary motivation was to update the /etc/default-isc-dhcp-server file to the new template introduced in Debian 9. Debian 8 is EOL so there's no point in trying to support the old format.