### PR TITLE
Ensure systemd drop-in happens before service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,8 +101,9 @@ class dhcp (
       if versioncmp($facts['os']['release']['major'], '7') >= 0 {
         include systemd
         systemd::dropin_file { 'interfaces.conf':
-          unit    => 'dhcpd.service',
-          content => template('dhcp/redhat/systemd-dropin.conf.erb'),
+          unit           => 'dhcpd.service',
+          content        => template('dhcp/redhat/systemd-dropin.conf.erb'),
+          notify_service => true,
         }
       } else {
         file { '/etc/sysconfig/dhcpd':


### PR DESCRIPTION
By using notify_service we ensure that the drop-in exists before the service is started and restarted if it changes.