### PR TITLE
Depend on camptocamp/systemd ~> 3.1

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,4 +5,4 @@ fixtures:
       puppet_version: '>= 6.0.0'
     concat:      'https://github.com/puppetlabs/puppetlabs-concat'
     stdlib:      'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-    systemd:     'https://github.com/camptocamp/puppet-systemd'
+    systemd:     'https://github.com/voxpupuli/puppet-systemd'

--- a/metadata.json
+++ b/metadata.json
@@ -16,8 +16,8 @@
   ],
   "dependencies": [
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 1.0.0 < 4.0.0"
+      "name": "puppet/systemd",
+      "version_requirement": ">= 3.1.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
In 8ab95bcd65cdb83f8d1ca4d5b4473880b6737eb7 a change was made that required at least version 3.1.0. This fixes the metadata to reflect that.