### PR TITLE
.fixtures.yml: Cleanup puppet_version

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,6 @@
 fixtures:
   repositories:
-    augeas_core:
-      repo: 'https://github.com/puppetlabs/puppetlabs-augeas_core'
-      puppet_version: '>= 6.0.0'
+    augeas_core: 'https://github.com/puppetlabs/puppetlabs-augeas_core'
     concat:      'https://github.com/puppetlabs/puppetlabs-concat'
     stdlib:      'https://github.com/puppetlabs/puppetlabs-stdlib.git'
     systemd:     'https://github.com/voxpupuli/puppet-systemd'


### PR DESCRIPTION
The setting isn't required anymore since the module supports puppet 6.15
and newer.