### PR TITLE
add support for raw configuration for host declarations.

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -8,10 +8,18 @@
 #
 # @param comment
 #   An optional comment for the host
+#
+# @param raw_append
+#   Host configuration to append as-is
+#
+# @param raw_prepend
+#   Host configuration to prepend as-is
 define dhcp::host (
   String $ip,
   Dhcp::Macaddress $mac,
   Optional[String] $comment=undef,
+  Optional[String] $raw_append = undef,
+  Optional[String] $raw_prepend = undef,
 ) {
 
   $host = $name

--- a/spec/defines/host_spec.rb
+++ b/spec/defines/host_spec.rb
@@ -60,6 +60,40 @@ describe 'dhcp::host' do
 
         it_behaves_like "a concat template"
       end
+
+      describe 'raw_prepend parameter' do
+        let(:params) { super().merge(raw_prepend: 'fixed-address6 FE80:0000:0000:0000:903A:1C1A:E802:11E4;') }
+
+        let(:expected_content) do
+          <<~CONTENT
+            host myhost {
+              fixed-address6 FE80:0000:0000:0000:903A:1C1A:E802:11E4;
+              hardware ethernet   01:02:03:04:05:06;
+              fixed-address       10.0.0.100;
+              ddns-hostname       "myhost";
+            }
+          CONTENT
+        end
+
+        it_behaves_like "a concat template"
+      end
+
+      describe 'raw_append parameter' do
+        let(:params) { super().merge(raw_append: 'dhcp-client-identifier "spec";') }
+
+        let(:expected_content) do
+          <<~CONTENT
+            host myhost {
+              hardware ethernet   01:02:03:04:05:06;
+              fixed-address       10.0.0.100;
+              ddns-hostname       "myhost";
+              dhcp-client-identifier "spec";
+            }
+          CONTENT
+        end
+
+        it_behaves_like "a concat template"
+      end
     end
   end
 end

--- a/templates/dhcpd.host.erb
+++ b/templates/dhcpd.host.erb
@@ -2,7 +2,13 @@
 # <%= @comment %>
 <% end -%>
 host <%= @host %> {
+<% if @raw_prepend -%>
+  <%= @raw_prepend %>
+<% end -%>
   hardware ethernet   <%= @mac %>;
   fixed-address       <%= @ip %>;
   ddns-hostname       "<%= @name %>";
+<% if @raw_append -%>
+  <%= @raw_append %>
+<% end -%>
 }


### PR DESCRIPTION
similar to the main config and subnet sections, this 
change adds support for appending/prepending raw
DHCPd configuration fragments to host sections.