### PR TITLE
Remove nameserver sorting for dhcp subnet configurations

### DIFF
--- a/templates/dhcpd.subnet.erb
+++ b/templates/dhcpd.subnet.erb
@@ -65,7 +65,7 @@ subnet <%= @network %> netmask <%= @mask %> {
   <%= @parameters %>;
 <% end -%>
 <% if @nameservers and @nameservers.is_a? Array -%>
-  option domain-name-servers <%= @nameservers.sort.join(', ') %>;
+  option domain-name-servers <%= @nameservers.join(', ') %>;
 <% elsif @nameservers -%>
   option domain-name-servers <%= @nameservers %>;
 <% end -%>


### PR DESCRIPTION
I tried to configure the nameserver with a example IP of 10.1.1.1 as my first priority nameserver in one of my configured DHCP pools.
```
nameservers:
      - '10.1.1.1'
      - '1.2.3.4'
      - '1.2.3.5'
```
But this nameserver was always landed as the last priority nameserver in /etc/dhcp/dhcpd.conf.
```
option domain-name-servers 1.2.3.4, 1.2.3.5, 10.1.1.1;
```
That's why I would suggest to remove the sort function for the nameservers array in the "dhcpd.subnet.erb" template.