### PR TITLE
debian grub2: update efi file name to align with symlink name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,9 +17,9 @@ class dhcp::params {
       $servicename = 'isc-dhcp-server'
       $root_group = 'root'
       $bootfiles = {
-        '00:06' => 'grub2/bootia32.efi',
-        '00:07' => 'grub2/bootx64.efi',
-        '00:09' => 'grub2/bootx64.efi',
+        '00:06' => 'grub2/grubia32.efi',
+        '00:07' => 'grub2/grubx64.efi',
+        '00:09' => 'grub2/grubx64.efi',
       }
     }
 


### PR DESCRIPTION
* the files with the path grub2/bootx64.efi do not exist on a ubuntu 20.04 installation with foreman 3.6.0
* during the foreman_proxy netboot setup, symlinks for the grub2 pxe efi files with the name grub2/shim.efi are created here https://github.com/theforeman/puppet-foreman_proxy/blob/1a42903ead90fa9622ac123511e5b5f9eece8f79/manifests/tftp/netboot.pp#L56-L76
* this change aligns the dhcpd bootfile path with the settings already used for RedHat distributions by also using the symlink created and fixes the current issue of non existent files with the name grub2/bootx64.efi