### PR TITLE
Drop badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-[![Puppet Forge](https://img.shields.io/puppetforge/v/theforeman/dhcp.svg)](https://forge.puppetlabs.com/theforeman/dhcp)
-[![Build Status](https://travis-ci.org/theforeman/puppet-dhcp.svg?branch=master)](https://travis-ci.org/theforeman/puppet-dhcp)
-
 # DHCP module for Puppet
 
 DHCP module for theforeman. Based on original DHCP module by ZLeslie, thanks


### PR DESCRIPTION
Back in 2020 with 1bd86090f0336db6a648a9adf6d8affe2e8bb4ef CI was switched over to GitHub Actions and the build status still links to Travis. Given nobody has noticed this, it's safe to delete this.