### PR TITLE
Add AlmaLinux 8 & 9 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -94,6 +94,13 @@
       "operatingsystemrelease": [
         "4"
       ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
     }
   ]
 }

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,5 +1,5 @@
-if $facts['os']['name'] == 'CentOS' {
-  package { 'epel-release':
+if $facts['os']['family'] == 'RedHat' and $facts['os']['name'] != 'Fedora' {
+    package { 'epel-release':
     ensure => installed,
     before => Package['dhcping'],
   }


### PR DESCRIPTION
Added AlmaLinux 8 and 9 to the supported operating systems in metadata.json.

These changes ensure that we start testing with AlmaLinux 8 and 9 instead of CentOS 8 Stream. This update is part of our transition to better support AlmaLinux in our Puppet modules.

See, for details: https://github.com/theforeman/foreman-infra/issues/2087