### PR TITLE
enable toggle for update-static-leases param for ddns enabled config

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,6 +2,11 @@
 #
 # @param option_static_route
 #   When enabled it sets the options rfc3442-classless-static-routes and ms-classless-static-routes
+# @param update_static_leases
+#   Whether to update static leases in DDNS. Valid values: 'on', 'off'.
+#   Setting to 'off' prevents DNS records from being modified for static leases.
+#   Default: 'on'
+
 class dhcp (
   Array[String] $dnsdomain = $dhcp::params::dnsdomain,
   Array[String] $nameservers = [],
@@ -37,10 +42,6 @@ class dhcp (
   String $dhcp_root_user = 'root',
   String $dhcp_root_group = $dhcp::params::root_group,
   Boolean $ddns_updates = false,
-  # @param update_static_leases
-  #   Whether to update static leases in DDNS. Valid values: 'on', 'off'.
-  #   Setting to 'off' prevents DNS records from being modified for static leases.
-  #   Default: 'on'
   Enum['on', 'off'] $update_static_leases = 'on',
   Optional[String] $ddns_domainname = undef,
   Optional[String] $ddns_rev_domainname = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,7 @@ class dhcp (
   String $dhcp_root_user = 'root',
   String $dhcp_root_group = $dhcp::params::root_group,
   Boolean $ddns_updates = false,
+  Boolean $update_static_leases = true,
   Optional[String] $ddns_domainname = undef,
   Optional[String] $ddns_rev_domainname = undef,
   Enum['none', 'interim', 'standard'] $ddns_update_style = 'interim',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,7 +37,11 @@ class dhcp (
   String $dhcp_root_user = 'root',
   String $dhcp_root_group = $dhcp::params::root_group,
   Boolean $ddns_updates = false,
-  Boolean $update_static_leases = true,
+  # @param update_static_leases
+  #   Whether to update static leases in DDNS. Valid values: 'on', 'off'.
+  #   Setting to 'off' prevents DNS records from being modified for static leases.
+  #   Default: 'on'
+  Enum['on', 'off'] $update_static_leases = 'on',
   Optional[String] $ddns_domainname = undef,
   Optional[String] $ddns_rev_domainname = undef,
   Enum['none', 'interim', 'standard'] $ddns_update_style = 'interim',

--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -26,7 +26,7 @@ not authoritative;
 <% if (@dnsupdatekey && !@dnsupdatekey.empty?) || @ddns_updates -%>
 ddns-updates on;
 ddns-update-style <%= @ddns_update_style %>;
-update-static-leases on;
+update-static-leases <%= @update_static_leases ? { true => 'on', false => 'off' } %>;
 use-host-decl-names on;
 <% if @client_updates == true -%>
 allow client-updates;

--- a/templates/dhcpd.conf.erb
+++ b/templates/dhcpd.conf.erb
@@ -26,7 +26,7 @@ not authoritative;
 <% if (@dnsupdatekey && !@dnsupdatekey.empty?) || @ddns_updates -%>
 ddns-updates on;
 ddns-update-style <%= @ddns_update_style %>;
-update-static-leases <%= @update_static_leases ? { true => 'on', false => 'off' } %>;
+update-static-leases <%= @update_static_leases %>;
 use-host-decl-names on;
 <% if @client_updates == true -%>
 allow client-updates;


### PR DESCRIPTION
forman-installer options support enabling ddns within dhcpd configuration when ddns is enabled via this module the parameter update-static-leases is hardcoded to on.
In a foreman environment where provisioning is mixed with non-provisioned host this causes a failure in Foreman provisioning as the DNS record for host.domain.com is removed and replaced with host.domain.com.domain.com which is both incorrect and a failure to the foreman build process as the node is defined in puppet as host.domain.com 

This functionality is useful outside of foreman for dhcp environments, 

while dhcp is deprecated to be replaced with kea, this is a minor update that I believe adds value 